### PR TITLE
Fixed bug where AR Maximum population was affected by habitability.

### DIFF
--- a/cs/fleet.go
+++ b/cs/fleet.go
@@ -911,7 +911,7 @@ func (fleet *Fleet) gateFleet(rules *Rules, mapObjectGetter mapObjectGetter, pla
 		messager.fleetStargateInvalidDestOwner(player, fleet, wp0, wp1)
 		return
 	}
-	if fleet.Cargo.Colonists > 0 && !sourcePlanet.OwnedBy(player.Num) {
+	if fleet.Cargo.Colonists > 0 && !sourcePlanet.OwnedBy(player.Num) && !player.Race.Spec.CanGateCargo {
 		messager.fleetStargateInvalidColonists(player, fleet, wp0, wp1)
 		return
 	}

--- a/cs/planet.go
+++ b/cs/planet.go
@@ -534,7 +534,7 @@ func (p *Planet) getMaxPopulation(rules *Rules, player *Player, habitability int
 	minMaxPop := float64(maxPossiblePop) * maxPopulationFactor * rules.MinMaxPopulationPercent
 
 	if player.Race.Spec.LivesOnStarbases && p.PlayerNum == player.Num {
-		maxPossiblePop = p.Starbase.Spec.MaxPopulation
+		return roundToNearest100f(float64(p.Starbase.Spec.MaxPopulation) * maxPopulationFactor)
 	}
 	return roundToNearest100f(math.Max(minMaxPop, float64(maxPossiblePop)*maxPopulationFactor*float64(habitability)/100.0))
 }

--- a/cs/scan.go
+++ b/cs/scan.go
@@ -382,6 +382,11 @@ func (scan *playerScan) getScanners() []scanner {
 				RangePenSquared: planetaryScanner.ScanRangePen * planetaryScanner.ScanRangePen,
 			}
 
+			if scan.player.Race.Spec.InnateScanner {
+				scanner.RangeSquared = planet.Spec.ScanRange * planet.Spec.ScanRange
+				scanner.RangePenSquared = planet.Spec.ScanRangePen * planet.Spec.ScanRangePen
+			}
+
 			// use the fleet scanner if it's better
 			if fleetScanner, ok := scanningFleetsByPosition[planet.Position]; ok {
 				scanner.RangeSquared = MaxInt(scanner.RangeSquared, fleetScanner.RangeSquared)

--- a/cs/turn.go
+++ b/cs/turn.go
@@ -805,7 +805,7 @@ func (t *turn) moveFleet(fleet *Fleet) {
 	updatedTokens := make([]ShipToken, 0, len(fleet.Tokens))
 	for tokenIndex := range fleet.Tokens {
 		token := &fleet.Tokens[tokenIndex]
-		if wp1.WarpSpeed > token.design.Spec.Engine.MaxSafeSpeed {
+		if wp1.WarpSpeed > token.design.Spec.Engine.MaxSafeSpeed && wp1.WarpSpeed != StargateWarpSpeed {
 			// explode some fleets if you go too fast
 			for shipIndex := 0; shipIndex < token.Quantity; shipIndex++ {
 				if t.game.Rules.FleetSafeSpeedExplosionChance > t.game.Rules.random.Float64() {


### PR DESCRIPTION
The maximum for an AR planet is only based on the star base size and whether the race has OBRM or not.

For example see: https://wiki.starsautohost.org/wiki/AR_Guide_by_Leonard_Dickens_-_Revised:_21st_September_2000
"Starbase Habitat: ARs live in starbases. Thus, while they use the planetary compat as do normal races for purposes of determining the growth-rate modification of the pop growth formula, they do *not* have the same planetary maximum populations. Instead, they get a fixed maxpop determined by the starbase type:"
