### PR TITLE
Fixed bug where NAS races do not benefit from doubling planetary scanner range.

### DIFF
--- a/cs/scan.go
+++ b/cs/scan.go
@@ -351,7 +351,6 @@ func (scan *playerScan) discoverPlayers() {
 // get a list of unique scanners per player.
 // This is a minimal list only containing the best scanner values for each position
 func (scan *playerScan) getScanners() []scanner {
-	planetaryScanner := scan.player.Spec.PlanetaryScanner
 	scanningFleetsByPosition := map[Vector]scanner{}
 	for _, fleet := range scan.universe.Fleets {
 		if fleet.Delete {
@@ -378,13 +377,8 @@ func (scan *playerScan) getScanners() []scanner {
 		if planet.PlayerNum == scan.player.Num && planet.Scanner {
 			scanner := scanner{
 				Position:        planet.Position,
-				RangeSquared:    planetaryScanner.ScanRange * planetaryScanner.ScanRange,
-				RangePenSquared: planetaryScanner.ScanRangePen * planetaryScanner.ScanRangePen,
-			}
-
-			if scan.player.Race.Spec.InnateScanner {
-				scanner.RangeSquared = planet.Spec.ScanRange * planet.Spec.ScanRange
-				scanner.RangePenSquared = planet.Spec.ScanRangePen * planet.Spec.ScanRangePen
+				RangeSquared:    planet.Spec.ScanRange * planet.Spec.ScanRange,
+				RangePenSquared: planet.Spec.ScanRangePen * planet.Spec.ScanRangePen,
 			}
 
 			// use the fleet scanner if it's better

--- a/cs/scan_test.go
+++ b/cs/scan_test.go
@@ -42,6 +42,10 @@ func Test_getScanners(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// planet scanners come from the spec
+			for _, planet := range tt.args.planets {
+				planet.Spec = computePlanetSpec(&rules, player, planet)
+			}
 			scan := playerScan{&Universe{
 				Planets:        tt.args.planets,
 				Fleets:         tt.args.fleets,

--- a/frontend/src/lib/components/game/tooltips/PopulationTooltip.svelte
+++ b/frontend/src/lib/components/game/tooltips/PopulationTooltip.svelte
@@ -31,7 +31,7 @@
 			{:else}
 				Your population on <span class="font-semibold">{planet.name}</span> is
 				<span class="font-semibold">{planet.spec.population.toLocaleString()}</span>.
-				<span class="font-semibold">{planet.name}</span> has a hostile environment and will no support
+				<span class="font-semibold">{planet.name}</span> has a hostile environment and will not support
 				any of your colonists.
 			{/if}
 			{#if planet.spec.growthAmount > 0}


### PR DESCRIPTION
`scan.getScanners()` recalculates the range of planetary scanners directly from the technology and does not include the effect of NAS. Thus, while the display shows the correct scanning range in both the command pane and the map pane, it is not used when determining what is visible during turn generation.

The planet Spec already has the correct ranges, so the PR uses them in `getScanners()`.