### PR TITLE
Various Battle Board bug fixes

### DIFF
--- a/cs/battle.go
+++ b/cs/battle.go
@@ -1005,10 +1005,6 @@ func (b *battle) getBestAttackMove(token *battleToken) BattleVector {
 
 			// if this will move us closer to our target, see if it's the best low damage move
 			if distance < currentDistance && bestDamageTakenForLowestDamageMove >= damageTaken {
-				// if this damage is the same, flip a coin to take this new move or not
-				if bestDamageTakenForLowestDamageMove == damageTaken && b.rules.random.Intn(2) == 0 {
-					break
-				}
 				bestDamageTakenForLowestDamageMove = damageTaken
 				lowestDamageMove = newPosition
 			}

--- a/cs/battle.go
+++ b/cs/battle.go
@@ -602,6 +602,9 @@ func (b *battle) findTargets(weapon *battleWeaponSlot, tokens []*battleToken) (t
 func (b *battle) findMoveTargets(tokens []*battleToken) bool {
 	hasTargets := false
 	for _, token := range tokens {
+		token.targetedBy = nil
+	}
+	for _, token := range tokens {
 		if token.Movement == 0 || !token.hasWeapons() || !token.isStillInBattle() {
 			continue
 		}

--- a/cs/battle.go
+++ b/cs/battle.go
@@ -999,7 +999,7 @@ func (b *battle) getBestAttackMove(token *battleToken) BattleVector {
 			damageDone := b.getDamageDone(token, distance)
 			damageTaken := 0
 			for _, attacker := range token.targetedBy {
-				distanceToAttacker := token.getDistanceAway(attacker.Position)
+				distanceToAttacker := newPosition.distance(attacker.Position)
 				damageTaken += b.getDamageDone(attacker, distanceToAttacker)
 			}
 

--- a/cs/battle.go
+++ b/cs/battle.go
@@ -1231,7 +1231,7 @@ func (b *battle) getSortedWeaponSlots(tokens []*battleToken) []*battleWeaponSlot
 		}
 	}
 	sort.Slice(slots, func(i, j int) bool {
-		return slots[i].initiative < slots[j].initiative
+		return slots[i].initiative > slots[j].initiative
 	})
 	return slots
 }


### PR DESCRIPTION
The first bug is a simple greater than less than typo. I noticed in my battles that the torpedoes with initiative 1 were firing before phasers with initiative 5 when both ships had initiative 4.

I found the second bug because I put a bunch of print statements into `getDamageDone()` to understand why tokens moved like they do and found that it was being called too often and so tokens expect to suffer more damage than they should. Setting `token.targetedBy` to be empty at the start of `findMoveTargets()` fixed this.

The third bug will randomly short circuit the decision of which position to move to. For example, if the token's target is to the left of the moving token, then if the first two positions being tested have the same `damageTaken` (highly likely if target is on the left) then no more positions will be examined due to the break. This is particularly problematic for torpedo/missile ships that would ideally want to move away from beamers, since they have longer range. (If randomness is required, then perhaps we should collect all equally best moves and select one at the end of the function.)

The fourth bug involves damage for a future position being calculated from the present position.

The fifth commit:
For maximise damage ratio:
The best outcome is to not be damaged at all (infinite damage ratio), in which case maximise absolute damage.
If cannot cause damage without being damaged, then get the best ratio.

For maximise net damage:
The reason for tracking `bestDamageDone` is to ensure damage is actually being done. If no damage is being done, then the if condition at the end of the function will choose to move closer to the target. I presume this is what should happen.