### PR TITLE
Bugfix: Re-enable intrinsic mining for Alternate Reality

### DIFF
--- a/cs/planet.go
+++ b/cs/planet.go
@@ -447,6 +447,8 @@ func computePlanetSpec(rules *Rules, player *Player, planet *Planet) PlanetSpec 
 	if !race.Spec.InnateMining {
 		spec.MaxMines = planet.getMaxMines(player, productivePop)
 		spec.MaxPossibleMines = spec.MaxPopulation * race.NumMines / 10000
+	} else {
+		spec.MaxMines = planet.Mines
 	}
 
 	if race.Spec.InnateResources {


### PR DESCRIPTION
A previous fix ([Planet mining/factory resources max out based on population](https://github.com/sirgwain/craig-stars/commit/ea3e16663262b6f4304162bd9841754a853e54c5)) set the number of mines operating to be the minimum of the number of mines existing and the number of mines that the population could operate. However, the number of mines that the population could operate was not set for races with intrinsic mining, and so was effectively zero.

This patch sets the number of mines that the population can operate to be equal to the number of intrinsic mines for races with intrinsic mining.