### PR TITLE
Battleviwer show undefined damage to shield #127

### DIFF
--- a/cs/battle.go
+++ b/cs/battle.go
@@ -734,11 +734,11 @@ func (b *battle) fireBeamWeapon(weapon *battleWeaponSlot, targets []*battleToken
 				if remainingDamage > 0 {
 					target.Damage = remainingDamage / float64(target.Quantity)
 					target.QuantityDamaged = target.Quantity
-					remainingDamage = 0
 					log.Debug().Msgf("%v destroyed %v ships, leaving %v damaged %v@%v damage", weapon.token, numDestroyed, target, target.Quantity, target.Damage)
 				}
 
 				b.record.recordBeamFire(b.round, weapon.token, weapon.token.Position, target.Position, weapon.slot.HullSlotIndex, *target, shields, int(remainingDamage)-shields, numDestroyed)
+				remainingDamage = 0
 			}
 
 		} else {


### PR DESCRIPTION
battle.go resets remainingDamage to 0 before calling recordBeamFire. This results in both damageDoneArmor and DamageDoneShields values becoming 0 in the BattleRecordTokenAction The frontend default to assume that if shield and armor damage is both 0 Then it print a damage to shield message which then access an unset variable resulting in the undefine message