### PR TITLE
Feature: Enable shift/control key for number spinners in research dialog…

### DIFF
--- a/frontend/src/lib/components/SpinnerNumber.svelte
+++ b/frontend/src/lib/components/SpinnerNumber.svelte
@@ -18,13 +18,13 @@
 	export let max = 100;
 	export let unit = '';
 
-	function increase() {
-		value = clamp(value + step, min, max);
+	function increase(e) {
+		value = clamp(value + step * (e.shiftKey ? 10 : 1) * (e.metaKey || e.ctrlKey ? 100 : 1), min, max);
 		dispatch('change', value);
 	}
 
-	function decrease() {
-		value = clamp(value - step, min, max);
+	function decrease(e) {
+		value = clamp(value - step * (e.shiftKey ? 10 : 1) * (e.metaKey || e.ctrlKey ? 100 : 1), min, max);
 		dispatch('change', value);
 	}
 </script>
@@ -38,10 +38,10 @@
 			{unit}
 		</div>
 		<div class="flex flex-col">
-			<button type="button" class="btn btn-xs" on:click={increase}>
+			<button type="button" class="btn btn-xs" on:click={(e) => increase(e)}>
 				<Icon src={ChevronUp} size="12" class="hover:stroke-accent" />
 			</button>
-			<button type="button" class="btn btn-xs" on:click={decrease}>
+			<button type="button" class="btn btn-xs" on:click={(e) => decrease(e)}>
 				<Icon src={ChevronDown} size="12" class="hover:stroke-accent" />
 			</button>
 		</div>


### PR DESCRIPTION
… and race creation dialog to advance by 10/100 when shift/control key pressed

This commit adds a feature that holding the shift key will change the step to 10 for clicking the number slider in the  research budget percentage on the research dialog and the econ values on the race dialog.

Similarly holding control will change the step to 100.

I do not know svelte so this may not be the best way to do it. I tried to import and call quantityModifier, but I could not get it working. So I copied the code directly into the increase and decrease functions.