### PR TITLE
Fix bug: Incorrect penetrating scanner range for first scanner

### DIFF
--- a/cs/shipdesign.go
+++ b/cs/shipdesign.go
@@ -518,7 +518,7 @@ func (spec *ShipDesignSpec) computeScanRanges(rules *Rules, scannerSpec ScannerS
 
 		if component.ScanRangePen != NoScanner {
 			if spec.ScanRangePen == NoScanner {
-				spec.ScanRangePen = component.ScanRangePen
+				spec.ScanRangePen = int((math.Pow(float64(component.ScanRangePen), 4)) * float64(slot.Quantity))
 			} else {
 				spec.ScanRangePen += int((math.Pow(float64(component.ScanRangePen), 4)) * float64(slot.Quantity))
 			}


### PR DESCRIPTION
The first scanner component has its penetrating scanner range taken to the fourth root without being taken to the fourth power first.