### PR TITLE
Use maximum warp when the fleet will be able to refuel at the next waypoint

### DIFF
--- a/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/Scanner.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/Scanner.svelte
@@ -512,8 +512,14 @@
 				? $selectedWaypoint?.warpSpeed
 				: engineIdealSpeed;
 
-		// if colonizing, we want the max possible warp
-		if (colonizing) {
+		// Technically the ship will refuel if the planet owner has the fleet owner set as friend.
+		// However, the fleet owner only knows who they set as a friend themselves.
+		// So we are assuming / trusting that the friendship has been reciprocated.
+		// Also, every player is friend to themselves.
+		let refuel = targetPlanet && targetPlanet.spec.hasStarbase && $player.isFriend(mo.playerNum)
+		
+		// if colonizing or will refuel, we want the max possible warp
+		if (colonizing || refuel) {
 			warpSpeed = $commandedFleet.getMaxWarp(
 				dist,
 				$universe,


### PR DESCRIPTION
This commit checks to see if the waypoint being added is a planet with a friendly star base where the fleet will refuel. If so, then it will automatically select the fastest warp speed allowed by the remaining fuel.

Technically we do not know whether the star base owner has set us to friend, which is required for us to refuel. Therefore, it is assumed that if we have the star base owner set to friend, then they will have reciprocated. If this is not the case, then we will not get to refuel but will have used the higher warp speed anyway.

This always works for our own star bases, because we are always friends with ourselves.