### PR TITLE
Ensure each position has maximum of one salvage

### DIFF
--- a/cs/universe.go
+++ b/cs/universe.go
@@ -496,13 +496,19 @@ func (u *Universe) createWormhole(rules *Rules, position Vector, stability Wormh
 	return wormhole
 }
 
-// delete a wormhole from the universe
+// find the salvage at a position, or create a new one
 func (u *Universe) createSalvage(position Vector, playerNum int, cargo Cargo) *Salvage {
+	salvage, exists := u.salvagesByPosition[position]
+	// Check for empty salvage, because they are deleted from database, but not mapObjects
+	if exists && (salvage.Cargo != Cargo{}) {
+		salvage.Cargo = salvage.Cargo.Add(cargo)
+		return salvage
+	}
 	num := 1
 	if len(u.Salvages) > 0 {
 		num = u.Salvages[len(u.Salvages)-1].Num + 1
 	}
-	salvage := newSalvage(position, num, playerNum, cargo)
+	salvage = newSalvage(position, num, playerNum, cargo)
 	u.Salvages = append(u.Salvages, salvage)
 	u.salvagesByNum[num] = salvage
 	u.addMapObjectByPosition(salvage, salvage.Position)


### PR DESCRIPTION
Currently each battle creates a separate salvage, even if there is already one present.
However, fleets at the position can only access the minerals in one of the salvages.
This patch searches for an existing salvage after a battle, and if present adds the minerals to it instead of creating a new one, so that fleets can access all minerals present.
Note 1: Code elsewhere deletes salvages in the database if they are empty, without deleting the salvage from memory. If minerals are added to a partially deleted salvage, then they will be lost forever. Therefore, the patch ignores empty salvages.
Note 2: The patch does not fix existing games that have multiple salvages in one position. It simply prevents it from happening in the future.