### PR TITLE
Allocating minerals on partially built items

### DIFF
--- a/cs/cost.go
+++ b/cs/cost.go
@@ -115,7 +115,7 @@ func (c Cost) AddCargoMinerals(other Cargo) Cost {
 	}
 }
 
-func (c Cost) Minus(other Cost) Cost {
+func (c Cost) Subtract(other Cost) Cost {
 	return Cost{
 		Ironium:   c.Ironium - other.Ironium,
 		Boranium:  c.Boranium - other.Boranium,
@@ -124,7 +124,7 @@ func (c Cost) Minus(other Cost) Cost {
 	}
 }
 
-func (c Cost) MinusMineral(other Mineral) Cost {
+func (c Cost) SubtractMineral(other Mineral) Cost {
 	return Cost{
 		Ironium:   c.Ironium - other.Ironium,
 		Boranium:  c.Boranium - other.Boranium,

--- a/cs/costcalculator.go
+++ b/cs/costcalculator.go
@@ -52,7 +52,7 @@ func (p *costCalculate) StarbaseUpgradeCost(rules *Rules, techLevels TechLevel, 
 	if design.Hull != newDesign.Hull {
 		oldHullCost := oldHull.Tech.GetPlayerCost(techLevels, raceSpec.MiniaturizationSpec, raceSpec.TechCostOffset).MultiplyInt(500 * rules.StarbaseComponentCostReduction)
 		newHullCost := newHull.Tech.GetPlayerCost(techLevels, raceSpec.MiniaturizationSpec, raceSpec.TechCostOffset).MultiplyInt(1000 * rules.StarbaseComponentCostReduction)
-		cost = cost.Add(newHullCost).Minus(oldHullCost)
+		cost = cost.Add(newHullCost).Subtract(oldHullCost)
 	}
 
 	// Next, iterate through both designs' slots and tally up items in each
@@ -182,7 +182,7 @@ func (p *costCalculate) StarbaseUpgradeCost(rules *Rules, techLevels TechLevel, 
 			minCost = minCost.AddInt(costType, adjCost)
 		}
 	}
-	cost = cost.Minus(credit).MinZero()
+	cost = cost.Subtract(credit).MinZero()
 	divisor := int(roundHalfDown(1000 * float64(rules.StarbaseComponentCostReduction) / raceSpec.StarbaseCostFactor))
 	cost = cost.Max(minCost).DivideByInt(divisor, true)
 	return cost, nil

--- a/cs/mineral.go
+++ b/cs/mineral.go
@@ -120,7 +120,7 @@ func (m Mineral) AddInt(num int) Mineral {
 }
 
 // subtract two minerals
-func (m Mineral) Minus(m2 Mineral) Mineral {
+func (m Mineral) Subtract(m2 Mineral) Mineral {
 	return Mineral{
 		Ironium:   m.Ironium - m2.Ironium,
 		Boranium:  m.Boranium - m2.Boranium,
@@ -129,7 +129,7 @@ func (m Mineral) Minus(m2 Mineral) Mineral {
 }
 
 // subtract the mineral components of a Cost
-func (m Mineral) MinusCost(m2 Cost) Mineral {
+func (m Mineral) SubtractCost(m2 Cost) Mineral {
 	return Mineral{
 		Ironium:   m.Ironium - m2.Ironium,
 		Boranium:  m.Boranium - m2.Boranium,

--- a/cs/orderer.go
+++ b/cs/orderer.go
@@ -114,6 +114,7 @@ func (o *orders) UpdatePlanetOrders(rules *Rules, player *Player, planet *Planet
 		Int64("GameID", player.GameID).
 		Int("PlayerNum", player.Num).
 		Str("Planet", planet.Name).
+		Interface("Orders", orders).
 		Msg("update planet orders")
 
 	return nil

--- a/cs/productionestimator.go
+++ b/cs/productionestimator.go
@@ -24,7 +24,7 @@ func NewCompletionEstimator() CompletionEstimator {
 
 // get the estimated years to build one item
 func (e *completionEstimate) GetYearsToBuildOne(item ProductionQueueItem, cost Cost, mineralsOnHand Mineral, yearlyAvailableToSpend Cost) int {
-	numBuiltInAYear := yearlyAvailableToSpend.Divide(cost.Minus(item.Allocated).MinusMineral(mineralsOnHand).MinZero())
+	numBuiltInAYear := yearlyAvailableToSpend.Divide(cost.Subtract(item.Allocated).SubtractMineral(mineralsOnHand).MinZero())
 	if numBuiltInAYear == 0 || math.IsInf(numBuiltInAYear, 1) {
 		return Infinite
 	}

--- a/cs/productionestimator_test.go
+++ b/cs/productionestimator_test.go
@@ -150,7 +150,7 @@ func Test_completionEstimate_GetProductionWithEstimates(t *testing.T) {
 					Quantity: 1,
 				},
 			},
-			wantLeftoverResources: 0,
+			wantLeftoverResources: 1,
 		},
 		{
 			name: "one item, two years to go",

--- a/cs/techlevel.go
+++ b/cs/techlevel.go
@@ -116,7 +116,7 @@ func (tl TechLevel) Add(other TechLevel) TechLevel {
 	}
 }
 
-func (tl TechLevel) Minus(tl2 TechLevel) TechLevel {
+func (tl TechLevel) Subtract(tl2 TechLevel) TechLevel {
 	return TechLevel{
 		tl.Energy - tl2.Energy,
 		tl.Weapons - tl2.Weapons,
@@ -213,5 +213,5 @@ func (tl TechLevel) LearnableTechFields(rules *Rules) []TechField {
 
 // get the lowest field missing from tl for a requirement
 func (tl TechLevel) LowestMissingLevel(requirement TechLevel) TechField {
-	return requirement.Minus(tl).MinZero().LowestNonZero()
+	return requirement.Subtract(tl).MinZero().LowestNonZero()
 }

--- a/cs/techtrader.go
+++ b/cs/techtrader.go
@@ -18,7 +18,7 @@ func newTechTrader() techTrader {
 // check for a tech level bonus from a player tech level and some target we scrapped, invaded, etc
 // https://wiki.starsautohost.org/wiki/Guts_of_Tech_Trading
 func (t *techTrade) techLevelGained(rules *Rules, current, target TechLevel) TechField {
-	diff := target.Minus(current).MinZero()
+	diff := target.Subtract(current).MinZero()
 	if diff.Sum() <= 0 {
 		return TechFieldNone
 	}

--- a/frontend/src/lib/components/NumberInput.svelte
+++ b/frontend/src/lib/components/NumberInput.svelte
@@ -15,6 +15,7 @@
 	export let max: number | undefined = undefined;
 	export let unitLabelClass = 'w-16';
 	export let required = false;
+	export let disabled = false;
 
 	$: !title && (title = startCase(name));
 </script>
@@ -27,6 +28,7 @@
 				<input
 					class={inputClass}
 					type="number"
+					{disabled}
 					{name}
 					{min}
 					{max}

--- a/frontend/src/lib/components/game/battle/BattleBoardAttack.svelte
+++ b/frontend/src/lib/components/game/battle/BattleBoardAttack.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import TorpedoHit from '$lib/components/icons/TorpedoHit.svelte';
 	import { Battle, TokenActionType } from '$lib/types/Battle';
-	import { emptyVector, minus } from '$lib/types/Vector';
-	import { tweened } from 'svelte/motion';
+	import { subtract } from '$lib/types/Vector';
 
 	export let battle: Battle;
 	export let phase: number;
@@ -12,7 +11,7 @@
 
 	$: actionToken = battle.getActionToken(phase ?? 0);
 	$: action = battle.getActionForPhase(phase ?? 0);
-	$: targetVector = action && actionToken && minus(action.to, actionToken);
+	$: targetVector = action && actionToken && subtract(action.to, actionToken);
 
 	// if we are doing a same square attack
 	$: targetVector && targetVector.x === 0 && targetVector.y === 0
@@ -23,7 +22,7 @@
 	// 	if (actionToken && action) {
 	// 		// $tweenedX = actionToken.x * 66 + 32;
 	// 		// $tweenedY = actionToken.y * 66 + 32;
-	// 		targetVector = minus(action.to, actionToken);
+	// 		targetVector = subtract(action.to, actionToken);
 	// 	} else {
 	// 		targetVector = emptyVector;
 	// 	}

--- a/frontend/src/lib/components/game/tooltips/AllocatedTooltip.svelte
+++ b/frontend/src/lib/components/game/tooltips/AllocatedTooltip.svelte
@@ -1,0 +1,25 @@
+<script lang="ts" context="module">
+	import { showTooltip } from '$lib/services/Stores';
+	import type { Cost } from '$lib/types/Cost';
+	import AllocatedTooltip from './AllocatedTooltip.svelte';
+
+	export function onAllocatedTooltip(e: PointerEvent | MouseEvent, cost: Cost | undefined) {
+		if (cost) {
+			showTooltip<AllocatedTooltipProps>(e.x, e.y, AllocatedTooltip, { cost });
+		}
+	}
+
+	export type AllocatedTooltipProps = {
+		cost: Cost;
+	};
+</script>
+
+<script lang="ts">
+	import CostMini from '../CostMini.svelte';
+
+	export let cost: Cost;
+</script>
+
+<div>
+	Allocated <CostMini {cost} />
+</div>

--- a/frontend/src/lib/types/Cost.ts
+++ b/frontend/src/lib/types/Cost.ts
@@ -37,16 +37,16 @@ export function add(a: Cost, b: Cost | Mineral | undefined): Cost {
 		ironium: (a.ironium ?? 0) + (b?.ironium ?? 0),
 		boranium: (a.boranium ?? 0) + (b?.boranium ?? 0),
 		germanium: (a.germanium ?? 0) + (b?.germanium ?? 0),
-		resources: (a.resources ?? 0) + (b && 'resources' in b ? b.resources ?? 0 : 0)
+		resources: (a.resources ?? 0) + (b && 'resources' in b ? (b.resources ?? 0) : 0)
 	};
 }
 
-export function minus(a: Cost, b: Cost | Mineral): Cost {
+export function subtract(a: Cost, b: Cost | Mineral): Cost {
 	return {
 		ironium: (a.ironium ?? 0) - (b.ironium ?? 0),
 		boranium: (a.boranium ?? 0) - (b.boranium ?? 0),
 		germanium: (a.germanium ?? 0) - (b.germanium ?? 0),
-		resources: (a.resources ?? 0) - ('resources' in b ? b.resources ?? 0 : 0)
+		resources: (a.resources ?? 0) - ('resources' in b ? (b.resources ?? 0) : 0)
 	};
 }
 

--- a/frontend/src/lib/types/Player.ts
+++ b/frontend/src/lib/types/Player.ts
@@ -2,7 +2,7 @@ import { fromHabType } from '$lib/services/Terraformer';
 import type { CostFinder, DesignFinder } from '$lib/services/Universe';
 import type { ProductionQueueItem } from '$lib/types/Production';
 import type { BattleAttackWho, BattleRecord, BattleTactic, BattleTarget } from './Battle';
-import { multiply, type Cost, minus, minZero } from './Cost';
+import { multiply, type Cost, subtract, minZero } from './Cost';
 import type { Fleet, WaypointTransportTasks } from './Fleet';
 import { HabTypes, type Hab } from './Hab';
 import type { Message } from './Message';
@@ -349,7 +349,7 @@ export class Player implements PlayerResponse, CostFinder {
 		updatedDesign: ShipDesign
 	): Cost {
 		// TODO: update this if we update the server side
-		return minZero(minus(updatedDesign.spec?.cost ?? {}, design.spec?.cost ?? {}));
+		return minZero(subtract(updatedDesign.spec?.cost ?? {}, design.spec?.cost ?? {}));
 	}
 
 	// get a player's ability to terraform

--- a/frontend/src/lib/types/TechLevel.ts
+++ b/frontend/src/lib/types/TechLevel.ts
@@ -36,7 +36,7 @@ export function hasRequiredLevels(tl: TechLevel, required: TechLevel): boolean {
 	);
 }
 
-export function minus(tl1: TechLevel, tl2: TechLevel): TechLevel {
+export function subtract(tl1: TechLevel, tl2: TechLevel): TechLevel {
 	return {
 		energy: (tl1.energy ?? 0) - (tl2.energy ?? 0),
 		weapons: (tl1.weapons ?? 0) - (tl2.weapons ?? 0),

--- a/frontend/src/lib/types/Vector.ts
+++ b/frontend/src/lib/types/Vector.ts
@@ -36,6 +36,6 @@ export const normalized = (from: Vector): Vector => {
 	return v;
 };
 
-export const minus = (from: Vector, to: Vector): Vector => {
-	return {x: from.x - to.x, y: from.y - to.y}
-}
+export const subtract = (from: Vector, to: Vector): Vector => {
+	return { x: from.x - to.x, y: from.y - to.y };
+};

--- a/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/ScannerWormholeLinks.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/ScannerWormholeLinks.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { getGameContext } from '$lib/services/GameContext';
-	import { minus, normalized } from '$lib/types/Vector';
+	import { subtract, normalized } from '$lib/types/Vector';
 	import type { LayerCake } from 'layercake';
 	import { getContext } from 'svelte';
 	import type { Writable } from 'svelte/store';
@@ -39,7 +39,7 @@
 					{ position: target?.position ?? wormhole.position }
 				];
 
-				const heading = normalized(minus(coords[0].position, coords[1].position));
+				const heading = normalized(subtract(coords[0].position, coords[1].position));
 				coords[0].position = {
 					x: (coords[0].position.x ?? 0) - heading.x * 3,
 					y: coords[0].position.y - heading.y * 3

--- a/frontend/src/routes/(user)/games/(game)/[id]/(plans)/transport-plans/TransportTask.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/(plans)/transport-plans/TransportTask.svelte
@@ -19,10 +19,21 @@
 		enumType={WaypointTaskTransportAction}
 		bind:value={action}
 		titleClass="hidden"
-		typeTitle={(value) => (!value || value === WaypointTaskTransportAction.None ? 'None' : startCase(value))}
+		typeTitle={(value) =>
+			!value || value === WaypointTaskTransportAction.None ? 'None' : startCase(value)}
 		showEmpty={true}
 	/>
 </div>
 <div>
-	<NumberInput titleClass="hidden" name={`amount${title}`} bind:value={amount} />
+	<NumberInput
+		titleClass="hidden"
+		name={`amount${title}`}
+		bind:value={amount}
+		disabled={action == undefined ||
+			action === WaypointTaskTransportAction.None ||
+			action === WaypointTaskTransportAction.LoadAll ||
+			action === WaypointTaskTransportAction.UnloadAll ||
+			action === WaypointTaskTransportAction.LoadDunnage ||
+			action === WaypointTaskTransportAction.LoadOptimal}
+	/>
 </div>

--- a/frontend/src/routes/(user)/games/(game)/[id]/(plans)/transport-plans/TransportTasks.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/(plans)/transport-plans/TransportTasks.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WaypointTransportTasks } from '$lib/types/Fleet';
+	import { WaypointTaskTransportAction, type WaypointTransportTasks } from '$lib/types/Fleet';
 	import TransportTasks from './TransportTask.svelte';
 
 	export let transportTasks: WaypointTransportTasks;
@@ -9,7 +9,7 @@
 	<!-- headers -->
 	<div />
 	<div class="text-center font-semibold col-span-2">Action</div>
-	<div class="text-center font-semibold">Amount</div>
+	<div class="text-center font-semibold">Amount (kT)</div>
 	<TransportTasks
 		title="Fuel"
 		textClass="text-fuel"
@@ -40,4 +40,11 @@
 		bind:action={transportTasks.colonists.action}
 		bind:amount={transportTasks.colonists.amount}
 	/>
+	{#if transportTasks.colonists.amount && (transportTasks.colonists.action === WaypointTaskTransportAction.LoadAmount || transportTasks.colonists.action === WaypointTaskTransportAction.UnloadAmount)}
+		<div class="col-start-2 col-span-3 ml-2">
+			<span class="italic"
+				>{(transportTasks.colonists.amount * 100).toLocaleString()} colonists</span
+			>
+		</div>
+	{/if}
 </div>

--- a/frontend/src/routes/(user)/games/(game)/[id]/dialogs/production/ProductionQueue.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/dialogs/production/ProductionQueue.svelte
@@ -10,6 +10,7 @@
 <script lang="ts">
 	import CostComponent from '$lib/components/game/Cost.svelte';
 	import ProductionQueueItemLine from '$lib/components/game/ProductionQueueItemLine.svelte';
+	import { onAllocatedTooltip } from '$lib/components/game/tooltips/AllocatedTooltip.svelte';
 	import { onShipDesignTooltip } from '$lib/components/game/tooltips/ShipDesignTooltip.svelte';
 	import QuantityModifierButtons from '$lib/components/QuantityModifierButtons.svelte';
 	import { addError, CSError } from '$lib/services/Errors';
@@ -157,14 +158,11 @@
 			return 0;
 		}
 
-		const cost = $player.getItemCost(item, $universe, $techs, planet, item.quantity);
-		const resourcePercent = cost.resources
-			? (item.allocated?.resources ?? 0) / cost.resources
-			: 1.0;
-		const mineralsPercent = divide(planet.cargo, { ...item.allocated, resources: 0 });
+		const costOfOne = $player.getItemCost(item, $universe, $techs, planet, 1);
+		const percent = divide(item.allocated ?? {}, costOfOne);
 
 		// if we are mineral or resource constrained, report the percent complete based on the lowest.
-		return Math.min(resourcePercent, mineralsPercent);
+		return percent;
 	}
 
 	function addAvailableItem(e: MouseEvent, item?: ProductionQueueItem) {
@@ -427,7 +425,7 @@
 </script>
 
 <div
-	class="flex flex-col h-full bg-base-200 shadow max-h-fit min-h-fit rounded-sm border-2 border-base-300 text-base"
+	class="flex flex-col h-full bg-base-200 shadow rounded-sm border-2 border-base-300 text-base"
 >
 	<div class="text-center"><h2 class="text-lg">{planet.name}</h2></div>
 	<div class="flex-col h-full w-full">
@@ -650,7 +648,16 @@
 								<CostComponent cost={selectedQueueItemCost} />
 								<div class="mt-1 text-base">
 									{#if selectedQueueItemPercentComplete}
-										{(selectedQueueItemPercentComplete * 100)?.toFixed()}% Done,
+										<button
+											type="button"
+											on:pointerdown={(e) =>
+												onAllocatedTooltip(e, selectedQueueItem?.allocated)}
+											>{(selectedQueueItemPercentComplete * 100)?.toFixed()}%<Icon
+												src={QuestionMarkCircle}
+												size="16"
+												class="cursor-help inline-block ml-1"
+											/> Done,</button
+										>
 									{/if}
 									Completion {getCompletionDescription(selectedQueueItem)}
 								</div>

--- a/frontend/src/routes/(user)/games/(game)/[id]/research/FutureTechs.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/research/FutureTechs.svelte
@@ -4,7 +4,7 @@
 	import { techs } from '$lib/services/Stores';
 	import { canLearnTech } from '$lib/types/Player';
 	import type { Tech } from '$lib/types/Tech';
-	import { TechField, get, hasRequiredLevels, minus, sum } from '$lib/types/TechLevel';
+	import { TechField, get, hasRequiredLevels, subtract, sum } from '$lib/types/TechLevel';
 
 	type FutureTech = {
 		tech: Tech;
@@ -25,7 +25,7 @@
 				!hasRequiredLevels($player.techLevels, tech.requirements)
 		)
 		.map((tech) => {
-			const distanceToLearn = minus(tech.requirements, $player.techLevels);
+			const distanceToLearn = subtract(tech.requirements, $player.techLevels);
 			// zero out any level differences we have already achieved
 			// i.e. if we are at level 5 for energy and this tech requires 3, distanceToLearn.Energy will equal -2
 			// this makes it zero


### PR DESCRIPTION
fixes #515, #389

Also: 
* renamed Minus to Subtract for consistency
* updated percentComplete client side calc (fixes #356)
* added popup to show allocated minerals
* updated TransportTasks to show colonists, readonly fields on LoadAll/UnloadAll, etc. (fixes #363)