### PR TITLE
Remove WM/PP extra starting scouts

### DIFF
--- a/cs/traits.go
+++ b/cs/traits.go
@@ -270,7 +270,6 @@ func wmSpec() PRTSpec {
 	}
 
 	spec.StartingPlanets[0].StartingFleets = []StartingFleet{
-		{"Long Range Scout", StartingFleetHullScout, 0, ShipDesignPurposeScout},
 		{"Santa Maria", StartingFleetHullColonyShip, 0, ShipDesignPurposeColonizer},
 		{"Armed Probe", StartingFleetHullScout, 1, ShipDesignPurposeFighterScout},
 	}
@@ -375,7 +374,6 @@ func ppSpec() PRTSpec {
 			StarbaseHull:       SpaceStation.Name,
 			StarbaseDesignName: "Starbase",
 			StartingFleets: []StartingFleet{
-				{"Long Range Scout", StartingFleetHullScout, 0, ShipDesignPurposeScout},
 				{"Long Range Scout", StartingFleetHullScout, 0, ShipDesignPurposeScout},
 				{"Santa Maria", StartingFleetHullColonyShip, 0, ShipDesignPurposeColonizer},
 			}, Homeworld: true,


### PR DESCRIPTION
What it says on the bin - WM started with 1 scout when it should have had none (only an armed probe + colonizer), while PP had 3 scouts (2 HW, 1 extra) instead of 2 
Fixes #591