### PR TITLE
pre casting split fleet damage as ints, allowing loss

### DIFF
--- a/cs/fleet.go
+++ b/cs/fleet.go
@@ -1525,7 +1525,7 @@ func (fleet *Fleet) repairFleet(log zerolog.Logger, rules *Rules, player *Player
 			repairAmount := Max(1, int(float64(token.design.Spec.Armor)*repairRate*player.Race.Spec.RepairFactor))
 
 			// Remove damage from this fleet by its armor * repairRate
-			token.Damage = math.Max(0, token.Damage-float64(repairAmount))
+			token.Damage = math.Floor(math.Max(0, token.Damage-float64(repairAmount)))
 			if token.Damage == 0 {
 				token.QuantityDamaged = 0
 			}
@@ -1552,7 +1552,7 @@ func (fleet *Fleet) repairStarbase(log zerolog.Logger, rules *Rules, player *Pla
 	repairAmount := Max(1, int(float64(token.design.Spec.Armor)*repairRate*player.Race.Spec.StarbaseRepairFactor))
 
 	// Remove damage from this fleet by its armor * repairRate
-	token.Damage = math.Max(0, fleet.Tokens[0].Damage-float64(repairAmount))
+	token.Damage = math.Floor(math.Max(0, fleet.Tokens[0].Damage-float64(repairAmount)))
 
 	log.Debug().
 		Int("Player", fleet.PlayerNum).

--- a/cs/orderer.go
+++ b/cs/orderer.go
@@ -404,11 +404,11 @@ func (o *orders) SplitFleet(rules *Rules, player *Player, playerFleets []*Fleet,
 	stackDamageByDesign := map[int]int{}
 	for _, token := range source.Tokens {
 		tokensByDesign[token.DesignNum] = &token
-		stackDamageByDesign[token.DesignNum] += int(token.Damage * float64(token.QuantityDamaged))
+		stackDamageByDesign[token.DesignNum] += int(token.Damage) * token.QuantityDamaged
 	}
 	if dest != nil {
 		for _, token := range dest.Tokens {
-			stackDamageByDesign[token.DesignNum] += int(token.Damage * float64(token.QuantityDamaged))
+			stackDamageByDesign[token.DesignNum] += int(token.Damage) * token.QuantityDamaged
 			if t, found := tokensByDesign[token.DesignNum]; found {
 				t.Quantity += token.Quantity
 				t.QuantityDamaged += token.QuantityDamaged
@@ -423,10 +423,10 @@ func (o *orders) SplitFleet(rules *Rules, player *Player, playerFleets []*Fleet,
 	splitStackDamageByDesign := map[int]int{}
 	for _, token := range request.SourceTokens {
 		splitTokensByDesign[token.DesignNum] = &token
-		splitStackDamageByDesign[token.DesignNum] += int(token.Damage * float64(token.QuantityDamaged))
+		splitStackDamageByDesign[token.DesignNum] += int(token.Damage) * token.QuantityDamaged
 	}
 	for _, token := range request.DestTokens {
-		splitStackDamageByDesign[token.DesignNum] += int(token.Damage * float64(token.QuantityDamaged))
+		splitStackDamageByDesign[token.DesignNum] += int(token.Damage) * token.QuantityDamaged
 		if t, found := splitTokensByDesign[token.DesignNum]; found {
 			t.Quantity += token.Quantity
 			t.QuantityDamaged += token.QuantityDamaged
@@ -445,9 +445,10 @@ func (o *orders) SplitFleet(rules *Rules, player *Player, playerFleets []*Fleet,
 			return nil, nil, fmt.Errorf("found token in original fleets but not in split request")
 		}
 
+		// we might lose a point of damage in a split/merge, that's ok
 		stackDamage := stackDamageByDesign[token.DesignNum]
 		splitStackDamage := splitStackDamageByDesign[token.DesignNum]
-		if splitToken.Quantity != token.Quantity || splitToken.QuantityDamaged != token.QuantityDamaged || stackDamage != splitStackDamage {
+		if splitToken.Quantity != token.Quantity || splitToken.QuantityDamaged != token.QuantityDamaged || Abs(stackDamage-splitStackDamage) > 1 {
 			return nil, nil, fmt.Errorf("token in original fleet has different quantity/damage that token in split request")
 		}
 	}
@@ -763,15 +764,15 @@ func (o *orders) Merge(rules *Rules, player *Player, fleets []*Fleet) (*Fleet, e
 			}
 
 			if token.QuantityDamaged > 0 {
-				mergingTokenTotalDamage := float64(token.QuantityDamaged) * token.Damage
+				mergingTokenTotalDamage := token.QuantityDamaged * int(token.Damage)
 				// the token we're merging in has damage
 				// figure out the total and add it to the fleet we're merging into
-				destTokenTotalDamage := float64(existingToken.QuantityDamaged) * existingToken.Damage
+				destTokenTotalDamage := existingToken.QuantityDamaged * int(existingToken.Damage)
 
 				// if we merge 2 damaged tokens in 1 damaged token, split the damage
 				// between the 3 damaged tokens
 				existingToken.QuantityDamaged += token.QuantityDamaged
-				existingToken.Damage = (mergingTokenTotalDamage + destTokenTotalDamage) / float64(existingToken.QuantityDamaged)
+				existingToken.Damage = math.Floor(float64(mergingTokenTotalDamage+destTokenTotalDamage) / float64(existingToken.QuantityDamaged))
 			}
 		}
 

--- a/cs/orderer_test.go
+++ b/cs/orderer_test.go
@@ -1655,7 +1655,7 @@ func Test_orders_SplitFleet(t *testing.T) {
 						Quantity:        3,
 						DesignNum:       1,
 						QuantityDamaged: 2,
-						Damage:          (10. + 5.) / 2.,
+						Damage:          7,
 					},
 				},
 			},

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -8,9 +8,8 @@ const port = 4173;
 
 export default defineConfig({
 	retries: process.env.CI ? 2 : 0, // set to 2 when running on CI
-	fullyParallel: !!process.env.CI,
-	/* Opt out of parallel tests on CI. */
-	workers: process.env.CI ? 1 : undefined,
+	// single threaded or we need to use a non memory db
+	workers: 1,
 
 	reporter: process.env.CI
 		? [


### PR DESCRIPTION
Allowing split fleet damage diff to vary by up to 1dp in the case of splitting a fleet with 1@5 and 1@10  = 2@7damage

fixes #418