### PR TITLE
Feature/split cargo fixes

### DIFF
--- a/cs/cargo.go
+++ b/cs/cargo.go
@@ -31,6 +31,15 @@ func NewCargoFromMineralsAndPop(mineral Mineral, pop int) Cargo {
 	}
 }
 
+func NewCargoFromArray(values [4]int) Cargo {
+	return Cargo{
+		Ironium:   values[0],
+		Boranium:  values[1],
+		Germanium: values[2],
+		Colonists: values[3],
+	}
+}
+
 func (c CargoType) String() string {
 	switch c {
 	case Ironium:
@@ -154,6 +163,15 @@ func (c Cargo) Total() int {
 	return c.Ironium + c.Boranium + c.Germanium + c.Colonists
 }
 
+func (c Cargo) ToArray() [4]int {
+	return [4]int{
+		c.Ironium,
+		c.Boranium,
+		c.Germanium,
+		c.Colonists,
+	}
+}
+
 // return true if this cargo can have transferAmount taken from it
 func (c Cargo) CanTransfer(transferAmount Cargo) bool {
 	return (c.Ironium >= transferAmount.Ironium &&
@@ -256,4 +274,15 @@ func (c Cargo) GreatestMineralType() CargoType {
 	}
 
 	return None
+}
+
+// split a cargo into two cargos based on capacity
+func (source Cargo) Split(sourceCapacity, capacity1, capacity2 int) (Cargo, Cargo, error) {
+	sourceArray := source.ToArray()
+	split1, split2, err := splitValues(sourceCapacity, capacity1, capacity2, (sourceArray[:])...)
+	if err != nil {
+		return Cargo{}, Cargo{}, err
+	}
+
+	return NewCargoFromArray([4]int(split1)), NewCargoFromArray([4]int(split2)), nil
 }

--- a/cs/cargo_test.go
+++ b/cs/cargo_test.go
@@ -1,6 +1,9 @@
 package cs
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestCargo_CanTransfer(t *testing.T) {
 	type args struct {
@@ -21,6 +24,100 @@ func TestCargo_CanTransfer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.cargo.CanTransfer(tt.args.transferAmount); got != tt.want {
 				t.Errorf("Cargo.CanTransfer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCargo_Split(t *testing.T) {
+	type args struct {
+		sourceCapacity int
+		capacity1      int
+		capacity2      int
+	}
+	tests := []struct {
+		name       string
+		source     Cargo
+		args       args
+		wantCargo1 Cargo
+		wantCargo2 Cargo
+		wantErr    bool
+	}{
+		{
+			name:    "invalid args",
+			source:  Cargo{1, 1, 1, 1},
+			args:    args{sourceCapacity: 4, capacity1: 5, capacity2: 0},
+			wantErr: true,
+		},
+		{
+			name:       "no split",
+			source:     Cargo{1, 1, 1, 1},
+			args:       args{sourceCapacity: 4, capacity1: 4, capacity2: 0},
+			wantCargo1: Cargo{1, 1, 1, 1},
+			wantCargo2: Cargo{},
+		},
+		{
+			name:       "split all",
+			source:     Cargo{1, 1, 1, 1},
+			args:       args{sourceCapacity: 4, capacity1: 0, capacity2: 4},
+			wantCargo1: Cargo{},
+			wantCargo2: Cargo{1, 1, 1, 1},
+		},
+		{
+			name:       "split even",
+			source:     Cargo{2, 2, 2, 2},
+			args:       args{sourceCapacity: 8, capacity1: 4, capacity2: 4},
+			wantCargo1: Cargo{1, 1, 1, 1},
+			wantCargo2: Cargo{1, 1, 1, 1},
+		},
+		{
+			name:       "split 1",
+			source:     Cargo{2, 2, 2, 2},
+			args:       args{sourceCapacity: 8, capacity1: 7, capacity2: 1},
+			wantCargo1: Cargo{2, 2, 2, 1},
+			wantCargo2: Cargo{0, 0, 0, 1},
+		},
+		{
+			name:       "split 2",
+			source:     Cargo{2, 2, 2, 2},
+			args:       args{sourceCapacity: 8, capacity1: 6, capacity2: 2},
+			wantCargo1: Cargo{2, 2, 2, 0},
+			wantCargo2: Cargo{0, 0, 0, 2},
+		},
+		{
+			name:       "split 3",
+			source:     Cargo{2, 2, 2, 2},
+			args:       args{sourceCapacity: 8, capacity1: 5, capacity2: 3},
+			wantCargo1: Cargo{1, 1, 1, 2},
+			wantCargo2: Cargo{1, 1, 1, 0},
+		},
+		{
+			name:       "split many",
+			source:     Cargo{100, 200, 300, 400},
+			args:       args{sourceCapacity: 2000, capacity1: 1500, capacity2: 500},
+			wantCargo1: Cargo{75, 150, 225, 300},
+			wantCargo2: Cargo{25, 50, 75, 100},
+		},
+		{
+			name:       "split 33%",
+			source:     Cargo{100, 0, 0, 0},
+			args:       args{sourceCapacity: 300, capacity1: 200, capacity2: 100},
+			wantCargo1: Cargo{67, 0, 0, 0},
+			wantCargo2: Cargo{33, 0, 0, 0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, got1, err := tt.source.Split(tt.args.sourceCapacity, tt.args.capacity1, tt.args.capacity2)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Cargo.Split() errored unexpectedly; err = %v", err)
+			}
+
+			if !reflect.DeepEqual(got, tt.wantCargo1) {
+				t.Errorf("Cargo.Split() got = %v, want %v", got, tt.wantCargo1)
+			}
+			if !reflect.DeepEqual(got1, tt.wantCargo2) {
+				t.Errorf("Cargo.Split() got1 = %v, want %v", got1, tt.wantCargo2)
 			}
 		})
 	}

--- a/cs/math.go
+++ b/cs/math.go
@@ -1,6 +1,7 @@
 package cs
 
 import (
+	"fmt"
 	"math"
 
 	"golang.org/x/exp/constraints"
@@ -29,6 +30,42 @@ func roundHalfTowards0(x float64) float64 {
 		return t + math.Copysign(1, x)
 	}
 	return t
+}
+
+func splitValues(sourceCapacity, destCapacity1, destCapacity2 int, values ...int) ([]int, []int, error) {
+	if destCapacity1+destCapacity2 != sourceCapacity {
+		return nil, nil, fmt.Errorf("bucket sizes must sum to %d", sourceCapacity)
+	}
+
+	bucket1 := make([]int, len(values))
+	bucket2 := make([]int, len(values))
+
+	remaining1 := destCapacity1
+	remaining2 := destCapacity2
+
+	for i, count := range values {
+		// Distribute proportionally
+		split1 := (count*destCapacity1 + sourceCapacity/2) / sourceCapacity // Round to nearest
+		split2 := count - split1
+
+		// Ensure we do not exceed the remaining capacity
+		if split2 > remaining2 {
+			split2 = remaining2
+			split1 = count - split2
+		}
+		if split1 > remaining1 {
+			split1 = remaining1
+			split2 = count - split1
+		}
+
+		bucket1[i] = split1
+		bucket2[i] = split2
+
+		remaining1 -= split1
+		remaining2 -= split2
+	}
+
+	return bucket1, bucket2, nil
 }
 
 // Clamps value between min and max and returns the result.

--- a/cs/math_test.go
+++ b/cs/math_test.go
@@ -1,6 +1,9 @@
 package cs
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func TestClamp(t *testing.T) {
 	type args struct {
@@ -90,6 +93,105 @@ func TestPowInt(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := PowInt(tt.base, tt.exponent); got != tt.want {
 				t.Errorf("PowInt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_splitValues(t *testing.T) {
+	type args struct {
+		sourceCapacity int
+		destCapacity1  int
+		destCapacity2  int
+		values         []int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want1   []int
+		want2   []int
+		wantErr bool
+	}{
+		{
+			name:    "invalid args",
+			args:    args{sourceCapacity: 4, destCapacity1: 5, destCapacity2: 0},
+			wantErr: true,
+		},
+		{
+			name:  "no split",
+			args:  args{sourceCapacity: 4, destCapacity1: 4, destCapacity2: 0, values: []int{1, 1, 1, 1}},
+			want1: []int{1, 1, 1, 1},
+			want2: []int{0, 0, 0, 0},
+		},
+		{
+			name: "split all",
+
+			args:  args{sourceCapacity: 4, destCapacity1: 0, destCapacity2: 4, values: []int{1, 1, 1, 1}},
+			want1: []int{0, 0, 0, 0},
+			want2: []int{1, 1, 1, 1},
+		},
+		{
+			name: "split even",
+
+			args:  args{sourceCapacity: 8, destCapacity1: 4, destCapacity2: 4, values: []int{2, 2, 2, 2}},
+			want1: []int{1, 1, 1, 1},
+			want2: []int{1, 1, 1, 1},
+		},
+		{
+			name: "split 1",
+
+			args:  args{sourceCapacity: 8, destCapacity1: 7, destCapacity2: 1, values: []int{2, 2, 2, 2}},
+			want1: []int{2, 2, 2, 1},
+			want2: []int{0, 0, 0, 1},
+		},
+		{
+			name: "split 2",
+
+			args:  args{sourceCapacity: 8, destCapacity1: 6, destCapacity2: 2, values: []int{2, 2, 2, 2}},
+			want1: []int{2, 2, 2, 0},
+			want2: []int{0, 0, 0, 2},
+		},
+		{
+			name: "split 3",
+
+			args:  args{sourceCapacity: 8, destCapacity1: 5, destCapacity2: 3, values: []int{2, 2, 2, 2}},
+			want1: []int{1, 1, 1, 2},
+			want2: []int{1, 1, 1, 0},
+		},
+		{
+			name: "split 2/3",
+
+			args:  args{sourceCapacity: 10, destCapacity1: 7, destCapacity2: 3, values: []int{3, 3, 3, 1}},
+			want1: []int{2, 2, 2, 1},
+			want2: []int{1, 1, 1, 0},
+		},
+		{
+			name: "split many",
+
+			args:  args{sourceCapacity: 2000, destCapacity1: 1500, destCapacity2: 500, values: []int{100, 200, 300, 400}},
+			want1: []int{75, 150, 225, 300},
+			want2: []int{25, 50, 75, 100},
+		},
+		{
+			name: "split 33%",
+
+			args:  args{sourceCapacity: 300, destCapacity1: 200, destCapacity2: 100, values: []int{100, 0, 0, 0}},
+			want1: []int{67, 0, 0, 0},
+			want2: []int{33, 0, 0, 0},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got1, got2, err := splitValues(tt.args.sourceCapacity, tt.args.destCapacity1, tt.args.destCapacity2, tt.args.values...)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("splitValues() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got1, tt.want1) {
+				t.Errorf("splitValues() got1 = %v, want %v", got1, tt.want1)
+			}
+			if !reflect.DeepEqual(got2, tt.want2) {
+				t.Errorf("splitValues() got2 = %v, want %v", got2, tt.want2)
 			}
 		})
 	}

--- a/cs/orderer.go
+++ b/cs/orderer.go
@@ -663,42 +663,20 @@ func (o *orders) splitFleetTokens(rules *Rules, player *Player, playerFleets []*
 	fleet.Tokens = tokens
 	fleet.FleetOrders = source.FleetOrders
 
-	// the fleet has some percentage of fuel fullness
-	fleetFuelFullness := float64(source.Fuel) / float64(source.Spec.FuelCapacity)
-
-	totalCargo := source.Cargo.Total()
-	totalCargoCapacity := source.Spec.CargoCapacity
+	// for splitting fuel and cargo
+	originalCargoCapacity := source.Spec.CargoCapacity
+	originalFuelCapacity := source.Spec.FuelCapacity
+	destCargoCapacity := 0
+	destFuelCapacity := 0
 
 	// now remove all the tokens from the old fleet
 	for i := range tokens {
 		splitToken := &tokens[i]
 		sourceToken := sourceTokensByDesign[splitToken.DesignNum]
-		// quantity := sourceToken.Quantity
-		// quantityDamaged := sourceToken.QuantityDamaged
 
-		// each ship in a token has some amount of fuel, based on the total fuel on the fleet
-		shipFuel := fleetFuelFullness * float64(sourceToken.design.Spec.FuelCapacity)
-
-		var shipCargoPercent float64 = 0
-		if totalCargo > 0 && splitToken.design.Spec.CargoCapacity > 0 {
-			// see how much this ship's cargo capacity is compared to the fleet total
-			shipCargoPercent = float64(splitToken.design.Spec.CargoCapacity) / float64(totalCargoCapacity)
-		}
-
-		// leave any remainder fuel on the source
-		fuelToMove := int(math.Floor(shipFuel * float64(splitToken.Quantity)))
-		fleet.Fuel += fuelToMove
-		source.Fuel -= fuelToMove
-
-		if totalCargo > 0 && shipCargoPercent > 0 {
-			fleet.Cargo = Cargo{
-				Ironium:   int(math.Floor(shipCargoPercent * float64(splitToken.Quantity) * float64(source.Cargo.Ironium))),
-				Boranium:  int(math.Floor(shipCargoPercent * float64(splitToken.Quantity) * float64(source.Cargo.Boranium))),
-				Germanium: int(math.Floor(shipCargoPercent * float64(splitToken.Quantity) * float64(source.Cargo.Germanium))),
-				Colonists: int(math.Floor(shipCargoPercent * float64(splitToken.Quantity) * float64(source.Cargo.Colonists))),
-			}
-			source.Cargo = source.Cargo.Subtract(fleet.Cargo)
-		}
+		// track how much cargo capacity our destination will get
+		destCargoCapacity += splitToken.design.Spec.CargoCapacity * splitToken.Quantity
+		destFuelCapacity += splitToken.design.Spec.FuelCapacity * splitToken.Quantity
 
 		// split damage
 		if sourceToken.QuantityDamaged > 0 {
@@ -718,6 +696,21 @@ func (o *orders) splitFleetTokens(rules *Rules, player *Player, playerFleets []*
 		}
 
 		sourceToken.Quantity -= splitToken.Quantity
+	}
+
+	fuel1, fuel2, err := splitValues(originalFuelCapacity, originalFuelCapacity-destFuelCapacity, destFuelCapacity, source.Fuel)
+	if err != nil {
+		return nil, fmt.Errorf("unable to split fuel %w", err)
+	}
+	source.Fuel = fuel1[0]
+	fleet.Fuel = fuel2[0]
+
+	// split cargo
+	if originalCargoCapacity > 0 {
+		source.Cargo, fleet.Cargo, err = source.Cargo.Split(originalCargoCapacity, originalCargoCapacity-destCargoCapacity, destCargoCapacity)
+		if err != nil {
+			return nil, fmt.Errorf("unable to split cargo %w", err)
+		}
 	}
 
 	// remove any empty tokens

--- a/cs/orderer_test.go
+++ b/cs/orderer_test.go
@@ -303,6 +303,67 @@ func Test_orders_SplitFleetTokens(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "split a single freighter out of 3, uneven cargo and fuel",
+			args: args{
+				player: player,
+				source: &Fleet{
+					MapObject: MapObject{
+						Type:      MapObjectTypeFleet,
+						Num:       1,
+						PlayerNum: player.Num,
+						Name:      "Teamster #1",
+					},
+					BaseName: "Teamster",
+					FleetOrders: FleetOrders{
+						Waypoints: []Waypoint{NewPositionWaypoint(Vector{}, 5)},
+					},
+					Tokens: []ShipToken{
+						{design: freighterDesign, DesignNum: freighterDesign.Num, Quantity: 3},
+					},
+					Fuel:  10,
+					Cargo: Cargo{10, 10, 10, 10},
+				},
+				tokens: []ShipToken{
+					{DesignNum: freighterDesign.Num, Quantity: 1}, // split out one freighter
+				},
+			},
+			wantSourceFleet: &Fleet{
+				MapObject: MapObject{
+					Type:      MapObjectTypeFleet,
+					Num:       1,
+					PlayerNum: player.Num,
+					Name:      "Teamster #1",
+				},
+				BaseName: "Teamster",
+				FleetOrders: FleetOrders{
+					Waypoints: []Waypoint{NewPositionWaypoint(Vector{}, 5)},
+				},
+				Tokens: []ShipToken{
+					{design: freighterDesign, DesignNum: freighterDesign.Num, Quantity: 2},
+				},
+				Fuel:  7,                 // keep 7/10 fuel
+				Cargo: Cargo{7, 7, 7, 7}, // 7/10 cargo
+			},
+			wantNewFleet: &Fleet{
+				MapObject: MapObject{
+					Type:      MapObjectTypeFleet,
+					Num:       2,
+					PlayerNum: player.Num,
+					Name:      "Teamster #2",
+				},
+				BaseName: "Teamster",
+				FleetOrders: FleetOrders{
+					Waypoints: []Waypoint{NewPositionWaypoint(Vector{}, 5)},
+				},
+				Tokens: []ShipToken{
+					{design: freighterDesign, DesignNum: freighterDesign.Num, Quantity: 1},
+				},
+				Fuel:  3,                 // keep 3 fuel
+				Cargo: Cargo{3, 3, 3, 3}, // keep 3 cargo
+			},
+			wantErr: false,
+		},
+		{
 			name: "split a scoutx2 with 1 damaged and freighterx3 with 3 damaged into two fleets",
 			args: args{
 				player: player,

--- a/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/ScannerSalvage.svelte
+++ b/frontend/src/routes/(user)/games/(game)/[id]/(main)/scanner/ScannerSalvage.svelte
@@ -27,12 +27,12 @@
 		fill="none"
 		class="rotate"
 	/>
-
-	<style>
-		.rotate {
-			transform-box: fill-box;
-			transform-origin: center;
-			transform: rotate(45deg);
-		}
-	</style>
 </MapObjectScaler>
+
+<style>
+	.rotate {
+		transform-box: fill-box;
+		transform-origin: center;
+		transform: rotate(45deg);
+	}
+</style>


### PR DESCRIPTION
Added utilities to split cargo
(also fixed bug where salvage wouldn't show up)

- [ ] Other Fleets Here Tile show other fleets for stealing
- [ ] Allow by hand cargo loads for any fleets orbiting a planet/fleet we know about cargo from
- [ ] Reset cargo knowledge every turn if we don't actively discover it
- [ ] Messages for various error cases when by hand transfers fail