### PR TITLE
Enable AR to upgrade starbases during peacetime

### DIFF
--- a/ai/producer.go
+++ b/ai/producer.go
@@ -171,12 +171,24 @@ func (ai *aiPlayer) buildOrUpgradeStarbase(planet *cs.Planet) error {
 	// if we are being targeted for bombing though, we want to try and build a starbase regardless
 	// TODO: Add ability to build fuel depots and infrastructure based on a (lower) cutoff
 	// This will be useful for IT/PP and desperately necessary for AR
-	planetaryStructuresBuilt := min(float64(planet.Mines)/float64(planet.Spec.MaxMines), float64(planet.Factories)/float64(planet.Spec.MaxFactories))
-	if !(targeted || attackShipsInOrbit) && planetaryStructuresBuilt < ai.config.fleetProductionCutoff {
-		// this will need to be changed for -f/AR races to work as
-		// they don't build mines & such regardless
-		// AR in particular will require entirely separate logic
-		return nil
+	if !(targeted || attackShipsInOrbit) {
+		if ai.Player.Race.Spec.InnateResources {
+			if !planet.Spec.CanTerraform { // Terraforming is economic development for AR planets
+				existingDesign := ai.GetDesign(planet.Spec.StarbaseDesignNum)
+				if len(existingDesign.Slots) == 0 && existingDesign != ai.fuelDepotDesign {
+					// Bigger starbase allows bigger population
+					ai.addStarbaseToTopOfQueue(planet, ai.fuelDepotDesign)
+				} else {
+					ai.upgradeStarbase(planet, ai.config.minYearsToQueueStarbasePeaceTime)
+				}
+			}
+			return nil
+		} else {
+			planetaryStructuresBuilt := min(float64(planet.Mines)/float64(planet.Spec.MaxMines), float64(planet.Factories)/float64(planet.Spec.MaxFactories))
+			if planetaryStructuresBuilt < ai.config.fleetProductionCutoff {
+				return nil
+			}
+		}
 	}
 
 	timeToWait := ai.config.minYearsToQueueStarbasePeaceTime

--- a/ai/producer.go
+++ b/ai/producer.go
@@ -173,14 +173,16 @@ func (ai *aiPlayer) buildOrUpgradeStarbase(planet *cs.Planet) error {
 	// This will be useful for IT/PP and desperately necessary for AR
 	if !(targeted || attackShipsInOrbit) {
 		if ai.Player.Race.Spec.InnateResources {
-			if !planet.Spec.CanTerraform { // Terraforming is economic development for AR planets
-				existingDesign := ai.GetDesign(planet.Spec.StarbaseDesignNum)
-				if len(existingDesign.Slots) == 0 && existingDesign != ai.fuelDepotDesign {
-					// Bigger starbase allows bigger population
-					ai.addStarbaseToTopOfQueue(planet, ai.fuelDepotDesign)
-				} else {
-					ai.upgradeStarbase(planet, ai.config.minYearsToQueueStarbasePeaceTime)
-				}
+			if planet.Spec.CanTerraform {
+				// Terraforming is economic development for AR planets
+				return nil
+			}
+			existingDesign := ai.GetDesign(planet.Spec.StarbaseDesignNum)
+			if len(existingDesign.Slots) == 0 && existingDesign != ai.fuelDepotDesign {
+				// Bigger starbase allows bigger population
+				ai.addStarbaseToTopOfQueue(planet, ai.fuelDepotDesign)
+			} else {
+				ai.upgradeStarbase(planet, ai.config.minYearsToQueueStarbasePeaceTime)
 			}
 			return nil
 		} else {


### PR DESCRIPTION
The existing code prevents AI planets building starbases in peacetime unless they have built half of the factories and mines that can be operated at the planet size.
This prevents AR from upgrading any starbases during peacetime because they do not build factories or mines at all.

Detailed code explanation:

```	if !(targeted || attackShipsInOrbit) {```
The original condition was "is it peacetime" and "is the planet developed enough".
This condition has been split with the "is it peacetime" part remaining above and different "development" conditions applied for AR and non-AR below.
```		if ai.Player.Race.Spec.InnateResources {```
The particular characteristic of AR that is relevant is the fact that they don't build factories.
```			if !planet.Spec.CanTerraform { // Terraforming is economic development for AR planets```
The production formula for AR resources includes the habitability as a factor.
Terraforming improves the habitability and thereby increases the resources produced by the planet.
```				existingDesign := ai.GetDesign(planet.Spec.StarbaseDesignNum)```
```				if len(existingDesign.Slots) == 0 && existingDesign != ai.fuelDepotDesign {```
```					// Bigger starbase allows bigger population```
```					ai.addStarbaseToTopOfQueue(planet, ai.fuelDepotDesign)```
If the existing design is an empty design then the first priority is increasing the size of the starbase so that the population can grow.
```ai.fuelDepotDesign``` is an empty starbase using the highest tech hull researched so far.
Unfortunately, this will never build a spacedock, because a space station hull is always "better" and has no tech requirements.
However, Ultrastations will be built in the relevant construction tech level range, if the AI has the ISB LRT.
For completeness: If anyone ever makes an ```InnateResources``` race that does not live on starbases then a ```LivesOnStarbases``` check should be added to the above condition so that they go straight to the weapons platform below.
```				} else {```
```					ai.upgradeStarbase(planet, ai.config.minYearsToQueueStarbasePeaceTime)```
If the starbase already uses the largest hull available, then it is time to put weapons on it.
If the starbase already has weapons, then we do not want to remove them, just to put them back later, so we go straight a design with weapons.
```				}```
```			}```
```			return nil```
For an AR we have already covered all peacetime options, so there is no point continuing.
If the planet is under attack then all of the new code will be bypassed and the wartime part of the existing code below will execute instead.
```		} else {```
```			planetaryStructuresBuilt := min(float64(planet.Mines)/float64(planet.Spec.MaxMines), float64(planet.Factories)/float64(planet.Spec.MaxFactories))```
```			if planetaryStructuresBuilt < ai.config.fleetProductionCutoff {```
```				return nil```
```			}```
The remaining code is identical to the original, except for rearrangements related to placing it in the else clause.
For completeness: If anyone ever makes a ```LivesOnStarbases``` race that does not have ```InnateResources``` then an else clause should be added here that leads to making an ai.fuelDepotDesign as above when the existing starbase does not have weapons.