### PR TITLE
Space Demolition players use a fleet scanner if it is better... 

### DIFF
--- a/cs/scan.go
+++ b/cs/scan.go
@@ -567,6 +567,12 @@ func (scan *playerScanner) getScanners() []scanner {
 				RangePen:             packet.ScanRangePen,
 				CloakReductionFactor: 1,
 			}
+			// use the fleet scanner if it's better
+			if fleetScanner, ok := scanningFleetsByPosition[packet.Position]; ok {
+				scanner.Range = max(scanner.Range, fleetScanner.Range)
+				scanner.RangePen = max(scanner.RangePen, fleetScanner.RangePen)
+				scanner.CloakReductionFactor = min(scanner.CloakReductionFactor, fleetScanner.CloakReductionFactor)
+			}
 			scanners = append(scanners, scanner)
 		}
 	}

--- a/cs/scan.go
+++ b/cs/scan.go
@@ -547,6 +547,12 @@ func (scan *playerScanner) getScanners() []scanner {
 					Range:                int(mineField.Spec.Radius),
 					CloakReductionFactor: 1,
 				}
+				// use the fleet scanner if it's better
+				if fleetScanner, ok := scanningFleetsByPosition[mineField.Position]; ok {
+					scanner.Range = max(scanner.Range, fleetScanner.Range)
+					scanner.RangePen = max(scanner.RangePen, fleetScanner.RangePen)
+					scanner.CloakReductionFactor = min(scanner.CloakReductionFactor, fleetScanner.CloakReductionFactor)
+				}
 				scanners = append(scanners, scanner)
 			}
 		}


### PR DESCRIPTION
...than a co-located minefield scanner

The scanner code is optimised to have only one scanner in each location. Special code is used to ensure that fleets located at planets get their scanner used if it is better than the planetary scanner. However, similar special code is lacking for Space Demolition minefields and Packet Physics packets.

This patch uses essentially similar code to the planet code for minefields and packets.