### PR TITLE
Jdrake/hab bar improvements

### DIFF
--- a/frontend/src/css/app.css
+++ b/frontend/src/css/app.css
@@ -91,15 +91,29 @@
 	.warp-packet-bar {
 		@apply bg-[#8F0087];
 	}
+
 	.grav-bar {
-		@apply bg-[#020085];
+		@apply fill-[#500fff];
 	}
 	.temp-bar {
-		@apply bg-[#8B0000];
+		@apply fill-[#D60000];
 	}
 	.rad-bar {
-		@apply bg-[#008100];
+		@apply fill-[#00C200];
 	}
+
+	.dark {
+		.grav-bar {
+			@apply fill-[#020085];
+		}
+		.temp-bar {
+			@apply fill-[#8B0000];
+		}
+		.rad-bar {
+			@apply fill-[#008100];
+		}
+	}
+
 	.grav-point {
 		@apply stroke-[#0900FF] fill-none;
 	}

--- a/frontend/src/routes/(user)/races/[id]/HabBar.svelte
+++ b/frontend/src/routes/(user)/races/[id]/HabBar.svelte
@@ -1,15 +1,6 @@
 <script lang="ts">
-	import { clamp } from '$lib/services/Math';
 	import { type HabType, Grav, Temp, Rad } from '$lib/types/cs';
-	import { getHabValueString, HabTypeShortString, habTypeString } from '$lib/types/Hab';
-	import { draggable, type DragEventData } from '@neodrag/svelte';
-	import {
-		ChevronDoubleLeft,
-		ChevronDoubleRight,
-		ChevronLeft,
-		ChevronRight
-	} from '@steeze-ui/heroicons';
-	import { Icon } from '@steeze-ui/svelte-icon';
+	import { clamp } from '$lib/services/Math';
 
 	type Props = {
 		habType: HabType;
@@ -25,118 +16,137 @@
 		immune = $bindable()
 	}: Props = $props();
 
-	let habTypeShortString = $derived(HabTypeShortString[habType]);
+	// immune can be undefined by default
+	let isImmune = $derived(!!immune);
 
-	let barContainerRef: HTMLDivElement | undefined = $state();
-	let containerWidth = $derived(barContainerRef?.parentElement?.clientWidth ?? 0);
+	let container: HTMLDivElement | undefined = $state();
+	let width: number | undefined = $state();
+	let height: number | undefined = $state();
 
-	let habWidth = $derived((habHigh ?? 0) - (habLow ?? 0));
-	let position = $derived(
-		barContainerRef
-			? {
-					x: Math.floor(((habLow ?? 0) / 100) * containerWidth),
-					y: 0
-				}
-			: undefined
+	let insetHeight = $derived(height != null ? height - 4 : undefined);
+	let insetWidth = $derived(width != null ? width - 4 : undefined);
+
+	let low = $derived(
+		insetWidth != null && habLow != null ? Math.trunc(insetWidth * (habLow / 100)) : undefined
+	);
+	let high = $derived(
+		insetWidth != null && habHigh != null ? Math.trunc(insetWidth * (habHigh / 100)) : undefined
+	);
+	let actualWidth = $derived(
+		insetWidth != null && low != null && high != null ? high - low : undefined
 	);
 
-	const onLeft = () => {
-		const width = habWidth;
-		habLow = clamp((habLow ?? 0) - 1, 0, 100 - width);
-		habHigh = clamp((habHigh ?? 0) - 1, width, 100);
+	let mouseDrag = false;
+	let mouseStart: number;
+	let mouseDelta: number = $state(0);
+	let habLowDrag: number | undefined;
+	let habHighDrag: number | undefined;
+
+	$effect(() => {
+		if (!insetWidth) {
+			return;
+		}
+
+		// delta in percentage
+		const delta = Math.trunc((mouseDelta / insetWidth) * 100);
+
+		console.log('mouse delta', mouseDelta, delta);
+
+		if (mouseDrag && habLowDrag != null && habHighDrag != null && !isImmune) {
+			if (habHigh != null && habLow != null) {
+				const w = habHigh - habLow;
+				if (habLowDrag + delta < 0) {
+					habLow = 0;
+					habHigh = w;
+					return;
+				} else if (habHighDrag + delta > 100) {
+					habLow = 100 - w;
+					habHigh = 100;
+					return;
+				}
+			}
+
+			habLow = clamp(habLowDrag + delta, 0, 100);
+			habHigh = clamp(habHighDrag + delta, 0, 100);
+
+			console.log('habLow', habLow);
+		}
+	});
+
+	const onmousedown = (mouseEvent: MouseEvent) => {
+		console.log('mouseDown', mouseEvent);
+		mouseDrag = true;
+		mouseStart = mouseEvent.clientX;
+		mouseDelta = 0;
+		habLowDrag = habLow;
+		habHighDrag = habHigh;
+
+		mouseEvent.preventDefault();
 	};
 
-	const onRight = () => {
-		const width = habWidth;
-		habLow = clamp((habLow ?? 0) + 1, 0, 100 - width);
-		habHigh = clamp((habHigh ?? 0) + 1, width, 100);
+	const onmouseup = (mouseEvent: MouseEvent) => {
+		console.log('mouseUp', mouseEvent);
+		mouseDrag = false;
 	};
 
-	const onGrow = () => {
-		const width = clamp(habWidth + 2, 20, 100);
-		habLow = clamp((habLow ?? 0) - 1, 0, 100 - width);
-		habHigh = clamp((habHigh ?? 0) + 1, width, 100);
-	};
-
-	const onShrink = () => {
-		const width = clamp(habWidth - 2, 20, 100);
-		habLow = clamp((habLow ?? 0) + 1, 0, (habHigh ?? 0) - width);
-		habHigh = clamp((habHigh ?? 0) - 1, habLow + width, 100);
-	};
-
-	const onDrag = (data: DragEventData) => {
-		const width = habWidth;
-		if (containerWidth && habLow) {
-			const pixelOffsetInPercent = Math.floor((data.offsetX / containerWidth) * 100);
-			habLow = clamp(pixelOffsetInPercent, 0, 100 - width);
-			habHigh = clamp(habLow + width, width, 100);
+	const onmousemove = (mouseEvent: MouseEvent) => {
+		if (mouseDrag) {
+			console.log('mouseMove', mouseEvent);
+			mouseDelta = mouseEvent.clientX - mouseStart;
+			console.log(mouseDelta);
 		}
 	};
+
+	const resizeObserver = new ResizeObserver((entries) => {
+		width = entries[0].contentRect.width;
+		height = entries[0].contentRect.height;
+	});
+
+	$effect(() => {
+		if (container) {
+			resizeObserver.disconnect();
+			resizeObserver.observe(container);
+		}
+	});
+
+	// $effect(() => {
+	// 	console.log('actualWidth', actualWidth);
+	// 	console.log('low', low);
+	// 	console.log('high', high);
+	// 	console.log('insetWidth', insetWidth);
+	// 	console.log('insetHeight', insetHeight);
+	// 	console.log('width', width);
+	// 	console.log('height', height);
+	// 	console.log('habLow', habLow);
+	// 	console.log('habHigh', habHigh);
+	// 	console.log('immune', immune);
+	// 	console.log('habType', habType);
+	// 	console.log('----------');
+	// });
 </script>
 
-<div class="flex flex-col md:flex-row">
-	<div class="text-center md:text-right md:w-[5.5rem] h-full my-auto mr-2">
-		{habTypeString(habType)}
-	</div>
-	<div class="grow flex flex-col">
-		<div class="flex flex-row h-8">
-			<button type="button" onclick={onLeft} class="btn btn-outline btn-sm"
-				><Icon src={ChevronLeft} size="20" />
-			</button>
+<svelte:document {onmouseup} {onmousemove} />
 
-			<div class="grow border-b border-base-300 bg-black mx-1 overflow-hidden h-full">
-				<div class="h-full" class:hidden={immune} bind:this={barContainerRef}>
-					{#if position}
-						<div
-							use:draggable={{ bounds: 'parent', position, onDrag }}
-							style={`width: ${habWidth.toFixed()}%`}
-							class="h-full"
-							class:grav-bar={habType === Grav}
-							class:temp-bar={habType === Temp}
-							class:rad-bar={habType === Rad}
-						></div>
-					{/if}
-				</div>
-			</div>
-			<button
-				type="button"
-				onclick={onRight}
-				class="btn btn-outline btn-sm"
-				data-type={`${habTypeShortString}-right-button`}
-				><Icon src={ChevronRight} size="20" />
-			</button>
-		</div>
-		<div class="flex flex-row grow mt-2">
-			<div>
-				<button
-					type="button"
-					onclick={onGrow}
-					class="btn btn-outline btn-sm"
-					data-type={`${habTypeShortString}-grow-button`}
-					><Icon src={ChevronDoubleLeft} size="20" />
-					<Icon src={ChevronDoubleRight} size="20" /></button
-				>
-			</div>
-			<div class="grow ml-2">
-				<label
-					><input type="checkbox" bind:checked={immune} /> Immune to {habTypeString(habType)}</label
-				>
-			</div>
-			<div>
-				<button
-					type="button"
-					onclick={onShrink}
-					class="btn btn-outline btn-sm"
-					data-type={`${habTypeShortString}-left-button`}
-					><Icon src={ChevronDoubleRight} size="20" />
-					<Icon src={ChevronDoubleLeft} size="20" /></button
-				>
-			</div>
-		</div>
-	</div>
-	<div class="flex flex-row gap-1 justify-center md:flex-col md:text-center md:ml-2 md:w-[5rem]">
-		<div class:hidden={immune}>{getHabValueString(habType, habLow ?? 0)}</div>
-		<div class:hidden={immune}>to</div>
-		<div class:hidden={immune}>{getHabValueString(habType, habHigh ?? 0)}</div>
-	</div>
+<div bind:this={container} class="grow px-1 overflow-hidden h-full">
+	<svg {width} {height} viewBox={`0 0 ${width} ${height}`}>
+		<rect x="0" y="0" {width} {height} fill="black"></rect>
+		{#if actualWidth != null && low != null && !isImmune}
+			<rect
+				class="cursor-pointer"
+				x={low + 2}
+				y="2"
+				width={actualWidth}
+				height={insetHeight}
+				fill="white"
+				{onmousedown}
+				{onmouseup}
+				{onmousemove}
+				role="menu"
+				tabindex="-1"
+				class:grav-bar={habType === Grav}
+				class:temp-bar={habType === Temp}
+				class:rad-bar={habType === Rad}
+			/>
+		{/if}
+	</svg>
 </div>

--- a/frontend/src/routes/(user)/races/[id]/HabBar.svelte
+++ b/frontend/src/routes/(user)/races/[id]/HabBar.svelte
@@ -7,14 +7,10 @@
 		habLow: number | undefined;
 		habHigh: number | undefined;
 		immune: boolean | undefined;
+		onValueChanged?: (low: number, high: number) => void | undefined;
 	};
 
-	let {
-		habType,
-		habLow = $bindable(),
-		habHigh = $bindable(),
-		immune = $bindable()
-	}: Props = $props();
+	let { habType, habLow, habHigh, immune, onValueChanged: onValueChanged }: Props = $props();
 
 	// immune can be undefined by default
 	let isImmune = $derived(!!immune);
@@ -23,8 +19,11 @@
 	let width: number | undefined = $state();
 	let height: number | undefined = $state();
 
-	let insetHeight = $derived(height != null ? height - 4 : undefined);
-	let insetWidth = $derived(width != null ? width - 4 : undefined);
+	// insetMargin specifies how much space to leave around the inset rectangle.
+	const insetMargin = 2;
+
+	let insetHeight = $derived(height != null ? height - insetMargin * 2 : undefined);
+	let insetWidth = $derived(width != null ? width - insetMargin * 2 : undefined);
 
 	let low = $derived(
 		insetWidth != null && habLow != null ? Math.trunc(insetWidth * (habLow / 100)) : undefined
@@ -36,66 +35,85 @@
 		insetWidth != null && low != null && high != null ? high - low : undefined
 	);
 
-	let mouseDrag = false;
-	let mouseStart: number;
-	let mouseDelta: number = $state(0);
-	let habLowDrag: number | undefined;
-	let habHighDrag: number | undefined;
+	let pointerDown = false;
+	let ref: SVGRectElement | undefined = $state();
+	let startValue: number | undefined;
+	let habLowStart: number | undefined;
+	let habHighStart: number | undefined;
 
-	$effect(() => {
-		if (!insetWidth) {
-			return;
+	function onPointerDown(e: PointerEvent) {
+		if (e.cancelable) {
+			e.preventDefault();
 		}
 
-		// delta in percentage
-		const delta = Math.trunc((mouseDelta / insetWidth) * 100);
+		if (!ref || !container) return;
 
-		console.log('mouse delta', mouseDelta, delta);
+		pointerDown = true;
 
-		if (mouseDrag && habLowDrag != null && habHighDrag != null && !isImmune) {
-			if (habHigh != null && habLow != null) {
-				const w = habHigh - habLow;
-				if (habLowDrag + delta < 0) {
-					habLow = 0;
-					habHigh = w;
-					return;
-				} else if (habHighDrag + delta > 100) {
-					habLow = 100 - w;
-					habHigh = 100;
-					return;
-				}
-			}
+		startValue = getPercentFromPointerEvent(e, container);
+		habLowStart = habLow;
+		habHighStart = habHigh;
 
-			habLow = clamp(habLowDrag + delta, 0, 100);
-			habHigh = clamp(habHighDrag + delta, 0, 100);
+		updateValue(getPercentFromPointerEvent(e, container));
 
-			console.log('habLow', habLow);
+		document.body.classList.add('select-none', 'touch-none');
+		document.body.classList.remove('touch-manipulation');
+
+		ref.setPointerCapture(e.pointerId);
+	}
+
+	function onPointerUp(e: PointerEvent) {
+		if (!ref) return;
+
+		document.body.classList.remove('select-none', 'touch-none');
+		document.body.classList.add('touch-manipulation');
+		pointerDown = false;
+		ref.releasePointerCapture(e.pointerId);
+	}
+
+	function onPointerMove(e: PointerEvent) {
+		if (e.cancelable) {
+			e.preventDefault();
 		}
-	});
 
-	const onmousedown = (mouseEvent: MouseEvent) => {
-		console.log('mouseDown', mouseEvent);
-		mouseDrag = true;
-		mouseStart = mouseEvent.clientX;
-		mouseDelta = 0;
-		habLowDrag = habLow;
-		habHighDrag = habHigh;
-
-		mouseEvent.preventDefault();
-	};
-
-	const onmouseup = (mouseEvent: MouseEvent) => {
-		console.log('mouseUp', mouseEvent);
-		mouseDrag = false;
-	};
-
-	const onmousemove = (mouseEvent: MouseEvent) => {
-		if (mouseDrag) {
-			console.log('mouseMove', mouseEvent);
-			mouseDelta = mouseEvent.clientX - mouseStart;
-			console.log(mouseDelta);
+		if (pointerDown && container) {
+			updateValue(getPercentFromPointerEvent(e, container));
 		}
-	};
+	}
+
+	// This is invoked when the pointer cannot give any more events,
+	// such as a touch event where scrolling has started to engage
+	function onPointerCancel(e: PointerEvent) {
+		if (!ref) return;
+
+		document.body.classList.remove('select-none', 'touch-none');
+		document.body.classList.add('touch-manipulation');
+		pointerDown = false;
+		ref.releasePointerCapture(e.pointerId);
+	}
+
+	function getPercentFromPointerEvent(e: PointerEvent, container: HTMLElement): number {
+		const boundingRect = container.getBoundingClientRect();
+
+		const x = e.clientX - boundingRect.left + insetMargin;
+		const w = boundingRect.width - insetMargin * 2;
+		const p = (x / w) * 100;
+
+		return clamp(p, 0, 100);
+	}
+
+	function updateValue(x: number) {
+		if (startValue != null && habLowStart != null && habHighStart != null) {
+			const delta = x - startValue;
+
+			const habWidth = habHighStart - habLowStart;
+
+			let newHabLow = clamp(Math.trunc(habLowStart + delta), 0, 100 - habWidth);
+			let newHabHigh = clamp(Math.trunc(newHabLow + habWidth), habWidth, 100);
+
+			onValueChanged?.(newHabLow, newHabHigh);
+		}
+	}
 
 	const resizeObserver = new ResizeObserver((entries) => {
 		width = entries[0].contentRect.width;
@@ -108,21 +126,6 @@
 			resizeObserver.observe(container);
 		}
 	});
-
-	// $effect(() => {
-	// 	console.log('actualWidth', actualWidth);
-	// 	console.log('low', low);
-	// 	console.log('high', high);
-	// 	console.log('insetWidth', insetWidth);
-	// 	console.log('insetHeight', insetHeight);
-	// 	console.log('width', width);
-	// 	console.log('height', height);
-	// 	console.log('habLow', habLow);
-	// 	console.log('habHigh', habHigh);
-	// 	console.log('immune', immune);
-	// 	console.log('habType', habType);
-	// 	console.log('----------');
-	// });
 </script>
 
 <svelte:document {onmouseup} {onmousemove} />
@@ -132,15 +135,17 @@
 		<rect x="0" y="0" {width} {height} fill="black"></rect>
 		{#if actualWidth != null && low != null && !isImmune}
 			<rect
-				class="cursor-pointer"
+				bind:this={ref}
+				class="cursor-pointer focus:outline-none"
 				x={low + 2}
 				y="2"
 				width={actualWidth}
 				height={insetHeight}
 				fill="white"
-				{onmousedown}
-				{onmouseup}
-				{onmousemove}
+				onpointerdown={onPointerDown}
+				onpointerup={onPointerUp}
+				onpointermove={onPointerMove}
+				onpointercancel={onPointerCancel}
 				role="menu"
 				tabindex="-1"
 				class:grav-bar={habType === Grav}

--- a/frontend/src/routes/(user)/races/[id]/Habitability.svelte
+++ b/frontend/src/routes/(user)/races/[id]/Habitability.svelte
@@ -2,7 +2,7 @@
 	import HabChance from '$lib/components/game/race/HabChance.svelte';
 	import { Grav, Rad, Temp, type Race } from '$lib/types/cs';
 	import SpinnerNumberText from '../../../../lib/components/SpinnerNumberText.svelte';
-	import HabBar from './HabBar.svelte';
+	import Habitation from './Habitation.svelte';
 
 	type Props = {
 		race: Race;
@@ -12,19 +12,19 @@
 </script>
 
 <div class="flex flex-col gap-2">
-	<HabBar
+	<Habitation
 		habType={Grav}
 		bind:habLow={race.habLow.grav}
 		bind:habHigh={race.habHigh.grav}
 		bind:immune={race.immuneGrav}
 	/>
-	<HabBar
+	<Habitation
 		habType={Temp}
 		bind:habLow={race.habLow.temp}
 		bind:habHigh={race.habHigh.temp}
 		bind:immune={race.immuneTemp}
 	/>
-	<HabBar
+	<Habitation
 		habType={Rad}
 		bind:habLow={race.habLow.rad}
 		bind:habHigh={race.habHigh.rad}

--- a/frontend/src/routes/(user)/races/[id]/Habitation.svelte
+++ b/frontend/src/routes/(user)/races/[id]/Habitation.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+	import { clamp } from '$lib/services/Math';
+	import { type HabType, Grav, Temp, Rad } from '$lib/types/cs';
+	import { getHabValueString, HabTypeShortString, habTypeString } from '$lib/types/Hab';
+	import { draggable, type DragEventData } from '@neodrag/svelte';
+	import {
+		ChevronDoubleLeft,
+		ChevronDoubleRight,
+		ChevronLeft,
+		ChevronRight
+	} from '@steeze-ui/heroicons';
+	import { Icon } from '@steeze-ui/svelte-icon';
+	import HabBar from './HabBar.svelte';
+
+	type Props = {
+		habType: HabType;
+		habLow: number | undefined;
+		habHigh: number | undefined;
+		immune: boolean | undefined;
+	};
+
+	let {
+		habType,
+		habLow = $bindable(),
+		habHigh = $bindable(),
+		immune = $bindable()
+	}: Props = $props();
+
+	let habTypeShortString = $derived(HabTypeShortString[habType]);
+
+	let barContainerRef: HTMLDivElement | undefined = $state();
+	let containerWidth = $derived(barContainerRef?.parentElement?.clientWidth ?? 0);
+
+	let habWidth = $derived((habHigh ?? 0) - (habLow ?? 0));
+	let position = $derived(
+		barContainerRef
+			? {
+					x: Math.floor(((habLow ?? 0) / 100) * containerWidth),
+					y: 0
+				}
+			: undefined
+	);
+
+	const onLeft = () => {
+		const width = habWidth;
+		habLow = clamp((habLow ?? 0) - 1, 0, 100 - width);
+		habHigh = clamp((habHigh ?? 0) - 1, width, 100);
+	};
+
+	const onRight = () => {
+		const width = habWidth;
+		habLow = clamp((habLow ?? 0) + 1, 0, 100 - width);
+		habHigh = clamp((habHigh ?? 0) + 1, width, 100);
+	};
+
+	const onGrow = () => {
+		const width = clamp(habWidth + 2, 20, 100);
+		habLow = clamp((habLow ?? 0) - 1, 0, 100 - width);
+		habHigh = clamp((habHigh ?? 0) + 1, width, 100);
+	};
+
+	const onShrink = () => {
+		const width = clamp(habWidth - 2, 20, 100);
+		habLow = clamp((habLow ?? 0) + 1, 0, (habHigh ?? 0) - width);
+		habHigh = clamp((habHigh ?? 0) - 1, habLow + width, 100);
+	};
+
+	const onDrag = ({ offsetX }: DragEventData) => {
+		const width = habWidth;
+		if (containerWidth && habLow) {
+			const pixelOffsetInPercent = Math.floor((offsetX / containerWidth) * 100);
+			habLow = clamp(pixelOffsetInPercent, 0, 100 - width);
+			habHigh = clamp(habLow + width, width, 100);
+		}
+	};
+
+	$effect(() => {
+		console.log('habWidth', habWidth, habWidth.toFixed());
+		console.log('position', position);
+	});
+</script>
+
+<div class="flex flex-col md:flex-row">
+	<div class="text-center md:text-right md:w-[5.5rem] h-full my-auto mr-2">
+		{habTypeString(habType)}
+	</div>
+	<div class="grow flex flex-col">
+		<div class="flex flex-row h-8">
+			<button type="button" onclick={onLeft} class="btn btn-outline btn-sm"
+				><Icon src={ChevronLeft} size="20" />
+			</button>
+
+			<HabBar {habType} bind:habLow bind:habHigh bind:immune />
+
+			<button
+				type="button"
+				onclick={onRight}
+				class="btn btn-outline btn-sm"
+				data-type={`${habTypeShortString}-right-button`}
+				><Icon src={ChevronRight} size="20" />
+			</button>
+		</div>
+		<div class="flex flex-row grow mt-2">
+			<div>
+				<button
+					type="button"
+					onclick={onGrow}
+					class="btn btn-outline btn-sm"
+					data-type={`${habTypeShortString}-grow-button`}
+					><Icon src={ChevronDoubleLeft} size="20" />
+					<Icon src={ChevronDoubleRight} size="20" /></button
+				>
+			</div>
+			<div class="grow ml-2">
+				<label
+					><input type="checkbox" bind:checked={immune} /> Immune to {habTypeString(habType)}</label
+				>
+			</div>
+			<div>
+				<button
+					type="button"
+					onclick={onShrink}
+					class="btn btn-outline btn-sm"
+					data-type={`${habTypeShortString}-left-button`}
+					><Icon src={ChevronDoubleRight} size="20" />
+					<Icon src={ChevronDoubleLeft} size="20" /></button
+				>
+			</div>
+		</div>
+	</div>
+	<div class="flex flex-row gap-1 justify-center md:flex-col md:text-center md:ml-2 md:w-[5rem]">
+		<div class:hidden={immune}>{getHabValueString(habType, habLow ?? 0)}</div>
+		<div class:hidden={immune}>to</div>
+		<div class:hidden={immune}>{getHabValueString(habType, habHigh ?? 0)}</div>
+	</div>
+</div>

--- a/frontend/src/routes/(user)/races/[id]/Habitation.svelte
+++ b/frontend/src/routes/(user)/races/[id]/Habitation.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
 	import { clamp } from '$lib/services/Math';
-	import { type HabType, Grav, Temp, Rad } from '$lib/types/cs';
+	import { type HabType } from '$lib/types/cs';
 	import { getHabValueString, HabTypeShortString, habTypeString } from '$lib/types/Hab';
-	import { draggable, type DragEventData } from '@neodrag/svelte';
 	import {
 		ChevronDoubleLeft,
 		ChevronDoubleRight,
@@ -28,18 +27,7 @@
 
 	let habTypeShortString = $derived(HabTypeShortString[habType]);
 
-	let barContainerRef: HTMLDivElement | undefined = $state();
-	let containerWidth = $derived(barContainerRef?.parentElement?.clientWidth ?? 0);
-
 	let habWidth = $derived((habHigh ?? 0) - (habLow ?? 0));
-	let position = $derived(
-		barContainerRef
-			? {
-					x: Math.floor(((habLow ?? 0) / 100) * containerWidth),
-					y: 0
-				}
-			: undefined
-	);
 
 	const onLeft = () => {
 		const width = habWidth;
@@ -65,19 +53,10 @@
 		habHigh = clamp((habHigh ?? 0) - 1, habLow + width, 100);
 	};
 
-	const onDrag = ({ offsetX }: DragEventData) => {
-		const width = habWidth;
-		if (containerWidth && habLow) {
-			const pixelOffsetInPercent = Math.floor((offsetX / containerWidth) * 100);
-			habLow = clamp(pixelOffsetInPercent, 0, 100 - width);
-			habHigh = clamp(habLow + width, width, 100);
-		}
-	};
-
-	$effect(() => {
-		console.log('habWidth', habWidth, habWidth.toFixed());
-		console.log('position', position);
-	});
+	function onValueChanged(low: number, high: number) {
+		habLow = low;
+		habHigh = high;
+	}
 </script>
 
 <div class="flex flex-col md:flex-row">
@@ -90,7 +69,7 @@
 				><Icon src={ChevronLeft} size="20" />
 			</button>
 
-			<HabBar {habType} bind:habLow bind:habHigh bind:immune />
+			<HabBar {habType} {habLow} {habHigh} {immune} {onValueChanged} />
 
 			<button
 				type="button"
@@ -128,7 +107,9 @@
 			</div>
 		</div>
 	</div>
-	<div class="flex flex-row gap-1 justify-center md:flex-col md:text-center md:ml-2 md:w-[5rem]">
+	<div
+		class="flex flex-row gap-1 leading-5 justify-center md:flex-col md:text-center md:ml-2 md:w-[5rem]"
+	>
 		<div class:hidden={immune}>{getHabValueString(habType, habLow ?? 0)}</div>
 		<div class:hidden={immune}>to</div>
 		<div class:hidden={immune}>{getHabValueString(habType, habHigh ?? 0)}</div>


### PR DESCRIPTION
Hab bar is now a separate component constructed using svg.

It uses pointer events and capture to handle the movement. Touch events need extra testing, in ios safari when scrolling happens it can lose the capture and the movement is cancelled. It appears to be designed for that.

Colour theme in light mode is brightened.

Line height of the ranges given are adjusted to 20px to make it so the text doesn't overflow the height of the hab section it belongs to. Pressing immunity will now not cause adjustments in sizes.

![image](https://github.com/user-attachments/assets/c0220c36-5e60-48a3-8e41-d9ef544416a0)
