### PR TITLE
using int64 as temporary value when computing scan ranges. 500^4 (pee…

### DIFF
--- a/cs/math.go
+++ b/cs/math.go
@@ -113,8 +113,8 @@ func AbsMin[S constraints.Signed | constraints.Float](nums ...S) S {
 // Raise an integer to the power of another integer and return the result.
 //
 // Does not support negative exponents (we *are* dealing with integers here after all)
-func PowInt[I constraints.Integer](base, exponent I) I {
-	var result I = 1
+func PowInt(base, exponent int64) int64 {
+	var result int64 = 1
 	// According to internet, this is the fastest way to do int exponentiation - by squaring
 	for exponent != 0 {
 		if exponent&1 == 1 {

--- a/cs/math_test.go
+++ b/cs/math_test.go
@@ -78,9 +78,9 @@ func Test_roundHalfTowards0(t *testing.T) {
 func TestPowInt(t *testing.T) {
 	tests := []struct {
 		name     string
-		base     int
-		exponent int
-		want     int
+		base     int64
+		exponent int64
+		want     int64
 	}{
 		{"1^4", 1, 4, 1},
 		{"2^3", 2, 3, 8},
@@ -88,6 +88,7 @@ func TestPowInt(t *testing.T) {
 		{"30^2", 30, 2, 900},
 		{"5^3", 5, 3, 125},
 		{"2^20", 2, 20, 1_048_576},
+		{"500^4", 500, 4, 62_500_000_000}, // peerless scanner 500ly^4
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cs/shipdesign.go
+++ b/cs/shipdesign.go
@@ -683,8 +683,9 @@ func ComputeShipDesignSpec(rules *Rules, techLevels TechLevel, raceSpec RaceSpec
 // Formula: (scanner1^4 + scanner2^4 + ...
 // + scannerN^4)^(0.25)
 func (spec *ShipDesignSpec) computeScanRanges(rules *Rules, scannerSpec ScannerSpec, techLevels TechLevel, design *ShipDesign, hull *TechHull) {
-	spec.ScanRange = 0
-	spec.ScanRangePen = 0
+	// we do some scanRange^4 calcs so we need temporary big nums
+	var scanRange int64
+	var scanRangePen int64
 	hasPenScan := false // counter to track if we have a pen scanner or not
 
 	// compute built in scanner if hull allows for it
@@ -693,11 +694,11 @@ func (spec *ShipDesignSpec) computeScanRanges(rules *Rules, scannerSpec ScannerS
 		builtInNormal := builtInScanner.NormalMulti.Multiply(techLevels).Total()
 		builtInPen := builtInScanner.PenMulti.Multiply(techLevels).Total()
 		if builtInNormal > 0 {
-			spec.ScanRange = PowInt(builtInNormal, 4)
+			scanRange = PowInt(int64(builtInNormal), 4)
 		}
 		if builtInPen > 0 {
-			spec.ScanRangePen = PowInt(builtInPen, 4)
-			hasPenScan = spec.ScanRangePen > 0
+			scanRangePen = PowInt(int64(builtInPen), 4)
+			hasPenScan = scanRangePen > 0
 		}
 	}
 
@@ -714,27 +715,31 @@ func (spec *ShipDesignSpec) computeScanRanges(rules *Rules, scannerSpec ScannerS
 
 		// Add (scanrange)^4 to our tally for both normal and pen scans
 		if component.ScanRange != NoScanner {
-			spec.ScanRange += PowInt(component.ScanRange, 4) * slot.Quantity
+			scanRange += PowInt(int64(component.ScanRange), 4) * int64(slot.Quantity)
 		}
 
 		if component.ScanRangePen != NoScanner {
 			hasPenScan = true
-			spec.ScanRangePen += PowInt(component.ScanRangePen, 4) * slot.Quantity
+			scanRangePen += PowInt(int64(component.ScanRangePen), 4) * int64(slot.Quantity)
 		}
 	}
 
 	// time to quad root everything
-	if spec.ScanRange > 0 {
-		s := math.Pow(float64(spec.ScanRange), .25) * scannerSpec.ScanRangeFactor
-		spec.ScanRange = int(math.Round(s))
+	if scanRange > 0 {
+		s := math.Pow(float64(scanRange), .25) * scannerSpec.ScanRangeFactor
+		scanRange = int64(math.Round(s))
 	}
 
-	if spec.ScanRangePen > 0 {
-		s := math.Pow(float64(spec.ScanRangePen), .25)
-		spec.ScanRangePen = int(math.Round(s))
+	if scanRangePen > 0 {
+		s := math.Pow(float64(scanRangePen), .25)
+		scanRangePen = int64(math.Round(s))
 	} else if !hasPenScan {
-		spec.ScanRangePen = NoScanner
+		scanRangePen = NoScanner
 	}
+
+	// set our spec values back to int versions
+	spec.ScanRange = int(scanRange)
+	spec.ScanRangePen = int(scanRangePen)
 
 	// Update scanner field if we have any scanning capabilities whatsoever
 	// all fleets should be able to regular scan at range 0 (i.e. see planet occupation status while in orbit), but not pen scan

--- a/cs/shiptoken.go
+++ b/cs/shiptoken.go
@@ -166,8 +166,8 @@ func (t *ShipToken) getOvergateMassVanishingChance(safeSourceMass int, maxMassFa
 	// Mass Vanishing % = 100/3*[1-(5*maxMass-mass)^2/(4*maxMass)^2], rounded down to nearest 1%.
 	// where maxMass is the maximum safe mass for the sending gate.
 	vanishingChance := 100.0 / 3 * (1 -
-		float64(PowInt(maxMassFactor*safeSourceMass-t.design.Spec.Mass, 2))/
-			float64(PowInt(4*safeSourceMass, 2)))
+		float64(PowInt(int64(maxMassFactor*safeSourceMass-t.design.Spec.Mass), 2))/
+			float64(PowInt(int64(4*safeSourceMass), 2)))
 
 	// return chance rounded down to nearest %
 	return math.Floor(vanishingChance) / 100

--- a/server/fleetservice.go
+++ b/server/fleetservice.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"log/slog"
+
 	"connectrpc.com/connect"
 	"github.com/sirgwain/craig-stars/cs"
 	"github.com/sirgwain/craig-stars/db"
 	"github.com/sirgwain/craig-stars/proto/converter"
 	craig_starsv1 "github.com/sirgwain/craig-stars/proto/gen/craig_stars/v1"
 	"github.com/sirgwain/craig-stars/proto/gen/craig_stars/v1/craig_starsv1connect"
-	"log/slog"
 )
 
 func NewFleetServiceHandler(db DBConnection) craig_starsv1connect.FleetServiceHandler {
@@ -59,6 +60,7 @@ func (s *fleetService) UpdateFleetOrders(ctx context.Context, req *connect.Reque
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	player.Race.Spec = cs.ComputeRaceSpec(&player.Race, &game.Rules)
 
 	fleet.InjectDesigns(player.Designs)
 
@@ -115,6 +117,7 @@ func (s *fleetService) MergeFleets(ctx context.Context, req *connect.Request[cra
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	player.Race.Spec = cs.ComputeRaceSpec(&player.Race, &game.Rules)
 
 	// Execute the merge
 	orderer := cs.NewOrderer()
@@ -190,6 +193,7 @@ func (s *fleetService) SplitAllFleets(ctx context.Context, req *connect.Request[
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	player.Race.Spec = cs.ComputeRaceSpec(&player.Race, &game.Rules)
 
 	fleets, err := dbClient.GetFleetsForPlayer(ctx, game.ID, gamePlayer.Num)
 	if err != nil {
@@ -244,6 +248,7 @@ func (s *fleetService) SplitFleet(ctx context.Context, req *connect.Request[crai
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, err)
 	}
+	player.Race.Spec = cs.ComputeRaceSpec(&player.Race, &game.Rules)
 
 	playerFleets, err := dbClient.GetFleetsForPlayer(ctx, game.ID, gamePlayer.Num)
 	if err != nil {

--- a/server/shipdesignservice.go
+++ b/server/shipdesignservice.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"fmt"
 
+	"log/slog"
+
 	"connectrpc.com/connect"
 	"github.com/sirgwain/craig-stars/cs"
 	"github.com/sirgwain/craig-stars/db"
 	"github.com/sirgwain/craig-stars/proto/converter"
 	craig_starsv1 "github.com/sirgwain/craig-stars/proto/gen/craig_stars/v1"
 	"github.com/sirgwain/craig-stars/proto/gen/craig_stars/v1/craig_starsv1connect"
-	"log/slog"
 )
 
 func NewshipDesignServiceHandler(db DBConnection) craig_starsv1connect.ShipDesignServiceHandler {
@@ -65,6 +66,7 @@ func (s *shipDesignService) CreateShipDesign(ctx context.Context, req *connect.R
 	if err != nil {
 		return nil, connect.NewError(connect.CodeInternal, fmt.Errorf("failed to load player: %w", err))
 	}
+	player.Race.Spec = cs.ComputeRaceSpec(&player.Race, &game.Rules)
 
 	design := converter.C.ConvertShipDesignP(req.Msg.Design)
 	if err := design.Validate(&game.Rules, player); err != nil {

--- a/wasm/wasm/wasmservice.go
+++ b/wasm/wasm/wasmservice.go
@@ -79,7 +79,7 @@ func (s *wasmService) ComputeRaceSpec(ctx context.Context, req *craig_starsv1.Co
 
 func (s *wasmService) ComputeShipDesignSpec(ctx context.Context, req *craig_starsv1.ComputeShipDesignSpecRequest) (*craig_starsv1.ComputeShipDesignSpecResponse, error) {
 	design := converter.C.ConvertShipDesignP(req.Design)
-	spec, err := cs.ComputeShipDesignSpec(s.rules, s.player.TechLevels, s.player.Race.Spec, design)
+	spec, err := cs.ComputeShipDesignSpec(s.rules, s.player.TechLevels, cs.ComputeRaceSpec(&s.player.Race, s.rules), design)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
…rless scanner calc) blows away int32 in tinygo.

fixes #705 