### PR TITLE
Logic bug around checking if AR can remote mine their own planets, ca…

### DIFF
--- a/cs/fleet.go
+++ b/cs/fleet.go
@@ -1393,7 +1393,7 @@ func (f *Fleet) CanFuel(player *Player, planet *Planet) bool {
 
 // CanRemoteMine returns true if this fleet can remote mine the planet
 func (f *Fleet) CanRemoteMine(player *Player, planet *Planet) bool {
-	return f.Spec.MiningRate > 0 && planet != nil && !planet.Owned() || (player.Race.Spec.CanRemoteMineOwnPlanets && planet.OwnedBy(player.Num))
+	return f.Spec.MiningRate > 0 && planet != nil && (!planet.Owned() || (player.Race.Spec.CanRemoteMineOwnPlanets && planet.OwnedBy(player.Num)))
 }
 
 // CanRemoteMine returns true if this fleet can remote mine the planet


### PR DESCRIPTION
…using nil pointer exception when trying to drag a waypoint. Also causing any planetary waypoints to be set to remote mining.

fixes #750